### PR TITLE
Add dev build mode

### DIFF
--- a/compiler/package.json
+++ b/compiler/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "clean": "rm -rf ../docs dist build",
     "build": "rollup -c",
+    "build:dev": "rollup -c --environment DEV",
     "dev": "ts-node src/bin",
     "test": "jest",
     "lint": "eslint src/**/*.ts",

--- a/compiler/rollup.config.js
+++ b/compiler/rollup.config.js
@@ -4,6 +4,8 @@ import alias from "@rollup/plugin-alias";
 
 import pkg from "./package.json";
 
+const dev = !!process.env.DEV;
+
 const external = [
   ...Object.keys(pkg.dependencies),
   "fs",
@@ -20,10 +22,12 @@ export default defineConfig([
       {
         file: "dist/index.cjs",
         format: "cjs",
+        sourcemap: dev,
       },
       {
         file: "dist/index.mjs",
         format: "esm",
+        sourcemap: dev,
       },
     ],
     plugins: [
@@ -32,6 +36,7 @@ export default defineConfig([
         compilerOptions: {
           declarationDir: "types",
           declaration: true,
+          sourceMap: dev,
         },
       }),
     ],
@@ -44,6 +49,7 @@ export default defineConfig([
       format: "cjs",
       entryFileNames: "[name].cjs",
       banner: "#!/usr/bin/env node",
+      sourcemap: dev,
     },
     external: /.+(?<!\.)/, // ignore everything that isn't a relative module
     plugins: [
@@ -57,6 +63,7 @@ export default defineConfig([
       }),
       typescript({
         tsconfig: "./tsconfig.json",
+        sourceMap: dev,
       }),
     ],
   },


### PR DESCRIPTION
Adds  a dev build mode to generate sourcemaps that allow debugging the library without shipping it on release mode.