### PR TITLE
Use deep eval

### DIFF
--- a/compiler/src/macros/Building.ts
+++ b/compiler/src/macros/Building.ts
@@ -1,4 +1,4 @@
-import { camelToDashCase, discardedName } from "../utils";
+import { camelToDashCase, deepEval, discardedName } from "../utils";
 import { InstructionBase, OperationInstruction } from "../instructions";
 import { IScope, IValue, TValueInstructions } from "../types";
 import { LiteralValue, ObjectValue, StoreValue } from "../values";
@@ -89,7 +89,7 @@ for (const key in operatorMap) {
     value: IValue
   ): TValueInstructions {
     this.ensureOwned();
-    const [right, rightInst] = value.eval(scope);
+    const [right, rightInst] = deepEval(scope, value);
     const temp = new StoreValue(scope);
     return [
       temp,

--- a/compiler/src/macros/Memory.ts
+++ b/compiler/src/macros/Memory.ts
@@ -12,6 +12,7 @@ class MemoryEntry extends ObjectValue {
   constructor(scope: IScope, mem: MemoryMacro, prop: IValue) {
     super(scope, {
       $eval: new MacroFunction(scope, () => {
+        if (this._store) return [this._store, []];
         this.ensureOwned();
         const temp = this.store;
         return [temp, [new InstructionBase("read", temp, mem.cell, prop)]];

--- a/compiler/src/macros/Namespace.ts
+++ b/compiler/src/macros/Namespace.ts
@@ -1,4 +1,4 @@
-import { camelToDashCase, discardedName } from "../utils";
+import { camelToDashCase, deepEval, discardedName } from "../utils";
 import { MacroFunction } from ".";
 import { IScope, IValue, TValueInstructions } from "../types";
 import { LiteralValue, ObjectValue, StoreValue } from "../values";
@@ -127,7 +127,7 @@ for (const key in operatorMap) {
     value: IValue
   ): TValueInstructions {
     this.ensureOwned();
-    const [right, rightInst] = value.eval(scope);
+    const [right, rightInst] = deepEval(scope, value);
     const temp = new StoreValue(scope);
     return [
       temp,

--- a/compiler/src/values/BaseValue.ts
+++ b/compiler/src/values/BaseValue.ts
@@ -9,10 +9,11 @@ import {
 import { IScope, IValue, TValueInstructions } from "../types";
 import { LiteralValue, VoidValue, StoreValue } from ".";
 import { ValueOwner } from "./ValueOwner";
+import { deepEval } from "../utils";
 
 export class BaseValue extends VoidValue implements IValue {
   "u-"(scope: IScope): TValueInstructions {
-    const [that, inst] = this.eval(scope);
+    const [that, inst] = deepEval(scope, this);
     const temp = new StoreValue(scope);
     return [
       temp,
@@ -64,8 +65,8 @@ for (const key in operatorMap) {
     value: IValue
   ): TValueInstructions {
     this.ensureOwned();
-    const [left, leftInst] = this.eval(scope);
-    const [right, rightInst] = value.eval(scope);
+    const [left, leftInst] = deepEval(scope, this);
+    const [right, rightInst] = deepEval(scope, value);
     const temp = new StoreValue(scope);
     return [
       temp,
@@ -91,7 +92,7 @@ for (const key in unaryOperatorMap) {
     scope: IScope
   ): TValueInstructions {
     this.ensureOwned();
-    const [that, inst] = this.eval(scope);
+    const [that, inst] = deepEval(scope, this);
     const temp = new StoreValue(scope);
     return [temp, [...inst, new OperationInstruction(name, temp, that, null)]];
   };
@@ -138,7 +139,7 @@ for (const key of updateOperators) {
     prefix: boolean
   ): TValueInstructions {
     this.ensureOwned();
-    let [ret, inst] = this.eval(scope);
+    let [ret, inst] = deepEval(scope, this);
     if (!prefix) {
       const tempOwner = new ValueOwner({ scope, value: new StoreValue(scope) });
       const temp = tempOwner.value;

--- a/compiler/src/values/StoreValue.ts
+++ b/compiler/src/values/StoreValue.ts
@@ -2,7 +2,7 @@ import { BaseValue, LiteralValue } from ".";
 import { CompilerError } from "../CompilerError";
 import { SetInstruction } from "../instructions";
 import { IScope, IValue, TValueInstructions } from "../types";
-import { discardedName } from "../utils";
+import { deepEval, discardedName } from "../utils";
 
 /**
  * `StoreValue` represents values unknown at compile time,
@@ -28,7 +28,7 @@ export class StoreValue extends BaseValue implements IValue {
       else value.owner.moveInto(this.owner);
       if (value instanceof StoreValue) return [this, []];
     }
-    const [evalValue, evalInst] = value.eval(scope);
+    const [evalValue, evalInst] = deepEval(scope, value);
     return [this, [...evalInst, new SetInstruction(this, evalValue)]];
   }
   eval(_scope: IScope): TValueInstructions {

--- a/compiler/src/values/ValueOwner.ts
+++ b/compiler/src/values/ValueOwner.ts
@@ -38,7 +38,7 @@ export class ValueOwner<T extends IValue = IValue> implements IValueOwner<T> {
     this.name = name ?? scope.makeTempName();
     this.temporary = !name;
     this.owned = new Set();
-    if (!value.owner) this.own(value);
+    if (!value.owner || value.owner.temporary) this.own(value);
   }
 
   own(target: T): void {
@@ -56,5 +56,6 @@ export class ValueOwner<T extends IValue = IValue> implements IValueOwner<T> {
 
   moveInto(owner: IValueOwner<T>): void {
     this.owned.forEach(value => owner.own(value));
+    this.owned.clear();
   }
 }

--- a/compiler/test/in/memory.js
+++ b/compiler/test/in/memory.js
@@ -1,10 +1,16 @@
-const mem = new Memory(getBuilding("cell1"));
+const bank = getBuilding("bank1");
+const message = getBuilding("message1");
 
-const bigMem = new Memory(getBuilding("bank1"), 512);
+const mem = new Memory(bank, 512); // tell the compiler the size of the memory unit. 64 by default
+print("Expecting ", mem.length, " bytes to be available");
 
-print("Mem size", mem.length, "\n");
-print("Big Mem size", bigMem.length, "\n");
+if (mem[0] == 0) {
+  mem[0] = 1;
+  print("Processor intialized");
+} else {
+  let runs = mem[1];
+  print("This code has run ", runs, " time(s)");
+  mem[1]++;
+}
 
-print("mem at 0", mem[0]);
-mem[0] = 120;
-print("mem at 0 again", mem[0]);
+printFlush(message);

--- a/compiler/test/out/memory.mlog
+++ b/compiler/test/out/memory.mlog
@@ -1,14 +1,18 @@
-print "Mem size"
-print 64
-print "\n"
-print "Big Mem size"
+print "Expecting "
 print 512
-print "\n"
-read &t0 cell1 0
-print "mem at 0"
-print &t0
-write 120 cell1 0
-read &t1 cell1 0
-print "mem at 0 again"
-print &t1
+print " bytes to be available"
+read &t0 bank1 0
+op equal &t1 &t0 0
+jump 9 equal &t1 0
+write 1 bank1 0
+print "Processor intialized"
+jump 16 always
+read runs bank1 1
+print "This code has run "
+print runs
+print " time(s)"
+read &t2 bank1 1
+op add &t3 &t2 1
+write &t3 bank1 1
+printflush message1
 end


### PR DESCRIPTION
Uses the `deepEval` util method to ensure that all values are evaluated at least once, ensuring that they are owned when consumed inside expressions.