### PR TITLE
Consistent array object values

### DIFF
--- a/compiler/src/handlers/Object.ts
+++ b/compiler/src/handlers/Object.ts
@@ -1,5 +1,5 @@
 import { CompilerError } from "../CompilerError";
-import { es, IInstruction, THandler } from "../types";
+import { es, IInstruction, IValue, THandler } from "../types";
 import { IObjectValueData, LiteralValue, ObjectValue } from "../values";
 import { ValueOwner } from "../values/ValueOwner";
 
@@ -42,15 +42,15 @@ export const ArrayExpression: THandler = (
   scope,
   node: es.ArrayExpression
 ) => {
-  const data: IObjectValueData = {};
+  const items: IValue[] = [];
   const inst: IInstruction[] = [];
-  node.elements.forEach((element, i) => {
+  node.elements.forEach(element => {
     if (!element) return;
     const [value, valueInst] = c.handleEval(scope, element);
-    data[i] = value;
+    items.push(value);
     inst.push(...valueInst);
   });
-  return [new ObjectValue(scope, data), inst];
+  return [ObjectValue.fromArray(scope, items), inst];
 };
 
 export const MemberExpression: THandler = (

--- a/compiler/src/macros/commands/UnitControl.ts
+++ b/compiler/src/macros/commands/UnitControl.ts
@@ -58,11 +58,7 @@ export class UnitControl extends MacroFunction<IValue | null> {
           const outType = new StoreValue(scope);
           const outBuilding = new Building(scope);
 
-          result = new ObjectValue(scope, {
-            0: outType,
-            1: outBuilding,
-            length: new LiteralValue(scope, 2),
-          });
+          result = ObjectValue.fromArray(scope, [outType, outBuilding]);
           extraArgs = [outType, outBuilding, new LiteralValue(scope, 0)];
           break;
         }

--- a/compiler/src/macros/commands/UnitLocate.ts
+++ b/compiler/src/macros/commands/UnitLocate.ts
@@ -73,13 +73,12 @@ export class UnitLocate extends MacroFunction {
         }
       }
       return [
-        new ObjectValue(scope, {
-          0: outFound,
-          1: outX,
-          2: outY,
-          3: outBuilding,
-          length: new LiteralValue(scope, find.data === "ore" ? 3 : 4),
-        }),
+        ObjectValue.fromArray(scope, [
+          outFound,
+          outX,
+          outY,
+          ...(find.data === "ore" ? [outBuilding] : []),
+        ]),
         [new InstructionBase("ulocate", ...inputArgs, ...outArgs)],
       ];
     });

--- a/compiler/src/values/ObjectValue.ts
+++ b/compiler/src/values/ObjectValue.ts
@@ -26,6 +26,17 @@ export class ObjectValue extends VoidValue {
     this.data = data;
   }
 
+  static fromArray(
+    scope: IScope,
+    items: IObjectValueData[keyof IObjectValueData][]
+  ): ObjectValue {
+    const data: IObjectValueData = {
+      length: new LiteralValue(scope, items.length),
+    };
+    items.forEach((item, i) => (data[i] = item));
+    return new ObjectValue(scope, data);
+  }
+
   typeof(scope: IScope): TValueInstructions {
     return [new LiteralValue(scope, "object"), []];
   }


### PR DESCRIPTION
This pull request adds an `ObjectValue.fromArray` factory to create object values from arrays consistently.

This fixes an issue where array macros could not have their `length` property accessed.