### PR TITLE
Value consume semantics

### DIFF
--- a/compiler/src/Compiler.ts
+++ b/compiler/src/Compiler.ts
@@ -5,7 +5,6 @@ import { initScope } from "./initScope";
 import { EndInstruction } from "./instructions";
 import { Scope } from "./Scope";
 import { es, IScope, IValue, THandler, TValueInstructions } from "./types";
-import { deepEval } from "./utils";
 
 type THandlerMap = { [k in es.Node["type"]]?: THandler<IValue | null> };
 
@@ -85,7 +84,15 @@ export class Compiler {
   handleEval(scope: IScope, node: es.Node): TValueInstructions {
     const [res, inst] = this.handle(scope, node);
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    return deepEval(scope, res!, inst);
+    const [evaluated, evaluatedInst] = res!.eval(scope);
+    return [evaluated, [...inst, ...evaluatedInst]];
+  }
+
+  handleConsume(scope: IScope, node: es.Node): TValueInstructions {
+    const [res, inst] = this.handle(scope, node);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const [evaluated, evaluatedInst] = res!.eval(scope);
+    return [evaluated, [...inst, ...evaluatedInst]];
   }
 
   handleMany<T extends es.Node>(

--- a/compiler/src/Compiler.ts
+++ b/compiler/src/Compiler.ts
@@ -91,7 +91,7 @@ export class Compiler {
   handleConsume(scope: IScope, node: es.Node): TValueInstructions {
     const [res, inst] = this.handle(scope, node);
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const [evaluated, evaluatedInst] = res!.eval(scope);
+    const [evaluated, evaluatedInst] = res!.consume(scope);
     return [evaluated, [...inst, ...evaluatedInst]];
   }
 

--- a/compiler/src/handlers/CallExpression.ts
+++ b/compiler/src/handlers/CallExpression.ts
@@ -9,7 +9,7 @@ export const CallExpression: THandler<IValue | null> = (
 
   const args = node.arguments.map(node => {
     // TODO: this might be why t0 did not increment
-    const [v, i] = c.handleEval(scope, node);
+    const [v, i] = c.handleConsume(scope, node);
     inst.push(...i);
     return v;
   });

--- a/compiler/src/handlers/ForStatement.ts
+++ b/compiler/src/handlers/ForStatement.ts
@@ -11,7 +11,7 @@ export const ForStatement: THandler<null> = (
 
   const initInst = node.init ? c.handle(scope, node.init)[1] : [];
   const [test, testLines] = node.test
-    ? c.handleEval(scope, node.test)
+    ? c.handleConsume(scope, node.test)
     : [new LiteralValue(scope, 1), []];
   const updateLines = node.update ? c.handle(scope, node.update)[1] : [];
   const startLoopAddr = new LiteralValue(scope, null as never);

--- a/compiler/src/handlers/IfStatement.ts
+++ b/compiler/src/handlers/IfStatement.ts
@@ -5,7 +5,7 @@ import { LiteralValue } from "../values";
 
 export const IfStatement: THandler<null> = (c, scope, node: es.IfStatement) => {
   const inst = [];
-  const [test, testInst] = c.handleEval(scope, node.test);
+  const [test, testInst] = c.handleConsume(scope, node.test);
 
   if (test instanceof LiteralValue) {
     if (test.data) inst.push(...c.handle(scope, node.consequent)[1]);

--- a/compiler/src/handlers/OperationExpressions.ts
+++ b/compiler/src/handlers/OperationExpressions.ts
@@ -15,8 +15,8 @@ export const LRExpression: THandler = (
     operator: AssignementOperator | BinaryOperator | LogicalOperator;
   }
 ) => {
-  const [left, leftInst] = c.handleEval(scope, node.left);
-  const [right, rightInst] = c.handleEval(scope, node.right);
+  const [left, leftInst] = c.handleConsume(scope, node.left);
+  const [right, rightInst] = c.handleConsume(scope, node.right);
   const [op, opInst] = left[node.operator](scope, right);
   return [op, [...leftInst, ...rightInst, ...opInst]];
 };
@@ -44,7 +44,7 @@ export const UnaryExpression: THandler = (
   scope,
   { argument, operator }: es.UnaryExpression
 ) => {
-  const [arg, argInst] = c.handleEval(scope, argument);
+  const [arg, argInst] = c.handleConsume(scope, argument);
   const operatorId =
     operator == "+" || operator == "-" ? (`u${operator}` as const) : operator;
   if (operatorId === "throw")

--- a/compiler/src/handlers/WhileStatement.ts
+++ b/compiler/src/handlers/WhileStatement.ts
@@ -8,7 +8,7 @@ export const WhileStatement: THandler<null> = (
   node: es.WhileStatement
 ) => {
   const lines: IInstruction[] = [];
-  const [test, testLines] = c.handleEval(scope, node.test);
+  const [test, testLines] = c.handleConsume(scope, node.test);
 
   const startLoopAddr = new LiteralValue(scope, null as never);
   const endLoopAddr = new LiteralValue(scope, null as never);

--- a/compiler/src/macros/Building.ts
+++ b/compiler/src/macros/Building.ts
@@ -54,11 +54,6 @@ export class Building extends ObjectValue {
       }),
     });
   }
-
-  eval(scope: IScope): TValueInstructions {
-    this.ensureOwned();
-    return super.eval(scope);
-  }
 }
 
 export class BuildingBuilder extends ObjectValue {

--- a/compiler/src/macros/Building.ts
+++ b/compiler/src/macros/Building.ts
@@ -1,4 +1,4 @@
-import { camelToDashCase, deepEval, discardedName } from "../utils";
+import { camelToDashCase, discardedName } from "../utils";
 import { InstructionBase, OperationInstruction } from "../instructions";
 import { IScope, IValue, TValueInstructions } from "../types";
 import { LiteralValue, ObjectValue, StoreValue } from "../values";
@@ -89,7 +89,7 @@ for (const key in operatorMap) {
     value: IValue
   ): TValueInstructions {
     this.ensureOwned();
-    const [right, rightInst] = deepEval(scope, value);
+    const [right, rightInst] = value.consume(scope);
     const temp = new StoreValue(scope);
     return [
       temp,

--- a/compiler/src/macros/Memory.ts
+++ b/compiler/src/macros/Memory.ts
@@ -4,7 +4,6 @@ import { IScope, IValue } from "../types";
 import { BaseValue, LiteralValue, ObjectValue, StoreValue } from "../values";
 import { MacroFunction } from "./Function";
 import { CompilerError } from "../CompilerError";
-import { deepEval } from "../utils";
 
 class MemoryEntry extends ObjectValue {
   private _store: StoreValue | null = null;
@@ -18,7 +17,7 @@ class MemoryEntry extends ObjectValue {
         return [temp, [new InstructionBase("read", temp, mem.cell, prop)]];
       }),
       "$=": new MacroFunction(scope, value => {
-        const [data, dataInst] = deepEval(scope, value);
+        const [data, dataInst] = value.consume(scope);
         return [
           data,
           [...dataInst, new InstructionBase("write", data, mem.cell, prop)],

--- a/compiler/src/macros/Namespace.ts
+++ b/compiler/src/macros/Namespace.ts
@@ -1,4 +1,4 @@
-import { camelToDashCase, deepEval, discardedName } from "../utils";
+import { camelToDashCase, discardedName } from "../utils";
 import { MacroFunction } from ".";
 import { IScope, IValue, TValueInstructions } from "../types";
 import { LiteralValue, ObjectValue, StoreValue } from "../values";
@@ -127,7 +127,7 @@ for (const key in operatorMap) {
     value: IValue
   ): TValueInstructions {
     this.ensureOwned();
-    const [right, rightInst] = deepEval(scope, value);
+    const [right, rightInst] = value.consume(scope);
     const temp = new StoreValue(scope);
     return [
       temp,

--- a/compiler/src/types.ts
+++ b/compiler/src/types.ts
@@ -119,6 +119,7 @@ export interface IValue extends IValueOperators {
   constant: boolean;
   macro: boolean;
   eval(scope: IScope): TValueInstructions;
+  consume(scope: IScope): TValueInstructions;
   call(scope: IScope, args: IValue[]): TValueInstructions<IValue | null>;
   get(scope: IScope, name: IValue): TValueInstructions;
   ensureOwned(): void;

--- a/compiler/src/types.ts
+++ b/compiler/src/types.ts
@@ -118,7 +118,16 @@ export interface IValue extends IValueOperators {
   scope: IScope;
   constant: boolean;
   macro: boolean;
+  /**
+   * Evaluates `this`, returning it's representation in a more basic
+   * value like `StoreValue` with the instructions required to compute that value
+   */
   eval(scope: IScope): TValueInstructions;
+  /**
+   * Does the same thing as {@link IValue.eval eval}, but ensures that the resulting value has an owner.
+   *
+   * This behaviour is required when dealing with temporary values inside expressions like comparations.
+   */
   consume(scope: IScope): TValueInstructions;
   call(scope: IScope, args: IValue[]): TValueInstructions<IValue | null>;
   get(scope: IScope, name: IValue): TValueInstructions;

--- a/compiler/src/types.ts
+++ b/compiler/src/types.ts
@@ -131,7 +131,11 @@ export interface IValue extends IValueOperators {
   consume(scope: IScope): TValueInstructions;
   call(scope: IScope, args: IValue[]): TValueInstructions<IValue | null>;
   get(scope: IScope, name: IValue): TValueInstructions;
-  ensureOwned(): void;
+  ensureOwned(): asserts this is IOwnedValue;
+}
+/** Helper type that is used in some typescript assertions */
+export interface IOwnedValue extends IValue {
+  owner: Exclude<IValue["owner"], null>;
 }
 
 export type TLiteral = string | number;

--- a/compiler/src/utils.ts
+++ b/compiler/src/utils.ts
@@ -1,4 +1,4 @@
-import { es, IInstruction, IScope, IValue, TValueInstructions } from "./types";
+import { es } from "./types";
 
 /**
  * The prefix for internal variables inside the compiler output
@@ -14,22 +14,4 @@ export function nodeName(node: es.Node) {
 
 export function camelToDashCase(name: string) {
   return name.replace(/[A-Z]/g, str => `-${str.toLowerCase()}`);
-}
-
-export function deepEval(
-  scope: IScope,
-  value: IValue,
-  instructions: IInstruction[] = []
-): TValueInstructions {
-  let last: IValue | null = null;
-  let current = value;
-
-  while (current != last) {
-    last = current;
-    const [res, resInst] = current.eval(scope);
-    current = res;
-    instructions = [...instructions, ...resInst];
-  }
-
-  return [current, instructions];
 }

--- a/compiler/src/values/BaseValue.ts
+++ b/compiler/src/values/BaseValue.ts
@@ -25,13 +25,6 @@ export class BaseValue extends VoidValue implements IValue {
   ensureOwned(): asserts this is IOwnedValue {
     this.owner ??= new ValueOwner({ scope: this.scope, value: this });
   }
-
-  consume(scope: IScope): TValueInstructions {
-    const result = this.eval(scope);
-    const res: IValue = result[0];
-    res.ensureOwned();
-    return result;
-  }
 }
 
 const operatorMap: Record<
@@ -96,7 +89,6 @@ for (const key in unaryOperatorMap) {
     this: BaseValue,
     scope: IScope
   ): TValueInstructions {
-    this.ensureOwned();
     const [that, inst] = this.consume(scope);
     const temp = new StoreValue(scope);
     return [temp, [...inst, new OperationInstruction(name, temp, that, null)]];
@@ -143,7 +135,6 @@ for (const key of updateOperators) {
     scope: IScope,
     prefix: boolean
   ): TValueInstructions {
-    this.ensureOwned();
     let [ret, inst] = this.consume(scope);
     if (!prefix) {
       const tempOwner = new ValueOwner({ scope, value: new StoreValue(scope) });

--- a/compiler/src/values/BaseValue.ts
+++ b/compiler/src/values/BaseValue.ts
@@ -9,11 +9,10 @@ import {
 import { IScope, IValue, TValueInstructions } from "../types";
 import { LiteralValue, VoidValue, StoreValue } from ".";
 import { ValueOwner } from "./ValueOwner";
-import { deepEval } from "../utils";
 
 export class BaseValue extends VoidValue implements IValue {
   "u-"(scope: IScope): TValueInstructions {
-    const [that, inst] = deepEval(scope, this);
+    const [that, inst] = this.consume(scope);
     const temp = new StoreValue(scope);
     return [
       temp,
@@ -70,9 +69,8 @@ for (const key in operatorMap) {
     scope: IScope,
     value: IValue
   ): TValueInstructions {
-    this.ensureOwned();
-    const [left, leftInst] = deepEval(scope, this);
-    const [right, rightInst] = deepEval(scope, value);
+    const [left, leftInst] = this.consume(scope);
+    const [right, rightInst] = value.consume(scope);
     const temp = new StoreValue(scope);
     return [
       temp,
@@ -98,7 +96,7 @@ for (const key in unaryOperatorMap) {
     scope: IScope
   ): TValueInstructions {
     this.ensureOwned();
-    const [that, inst] = deepEval(scope, this);
+    const [that, inst] = this.consume(scope);
     const temp = new StoreValue(scope);
     return [temp, [...inst, new OperationInstruction(name, temp, that, null)]];
   };
@@ -145,7 +143,7 @@ for (const key of updateOperators) {
     prefix: boolean
   ): TValueInstructions {
     this.ensureOwned();
-    let [ret, inst] = deepEval(scope, this);
+    let [ret, inst] = this.consume(scope);
     if (!prefix) {
       const tempOwner = new ValueOwner({ scope, value: new StoreValue(scope) });
       const temp = tempOwner.value;

--- a/compiler/src/values/BaseValue.ts
+++ b/compiler/src/values/BaseValue.ts
@@ -28,7 +28,7 @@ export class BaseValue extends VoidValue implements IValue {
 
   consume(scope: IScope): TValueInstructions {
     const result = this.eval(scope);
-    if (!result[0].owner) new ValueOwner({ scope, value: result[0] });
+    result[0].ensureOwned();
     return result;
   }
 }

--- a/compiler/src/values/BaseValue.ts
+++ b/compiler/src/values/BaseValue.ts
@@ -26,6 +26,12 @@ export class BaseValue extends VoidValue implements IValue {
   ensureOwned(): void {
     this.owner ??= new ValueOwner({ scope: this.scope, value: this });
   }
+
+  consume(scope: IScope): TValueInstructions {
+    const result = this.eval(scope);
+    if (!result[0].owner) new ValueOwner({ scope, value: result[0] });
+    return result;
+  }
 }
 
 const operatorMap: Record<

--- a/compiler/src/values/BaseValue.ts
+++ b/compiler/src/values/BaseValue.ts
@@ -6,7 +6,7 @@ import {
   UnaryOperator,
   updateOperators,
 } from "../operators";
-import { IScope, IValue, TValueInstructions } from "../types";
+import { IOwnedValue, IScope, IValue, TValueInstructions } from "../types";
 import { LiteralValue, VoidValue, StoreValue } from ".";
 import { ValueOwner } from "./ValueOwner";
 
@@ -22,13 +22,14 @@ export class BaseValue extends VoidValue implements IValue {
       ],
     ];
   }
-  ensureOwned(): void {
+  ensureOwned(): asserts this is IOwnedValue {
     this.owner ??= new ValueOwner({ scope: this.scope, value: this });
   }
 
   consume(scope: IScope): TValueInstructions {
     const result = this.eval(scope);
-    result[0].ensureOwned();
+    const res: IValue = result[0];
+    res.ensureOwned();
     return result;
   }
 }

--- a/compiler/src/values/LiteralValue.ts
+++ b/compiler/src/values/LiteralValue.ts
@@ -32,6 +32,9 @@ export class LiteralValue extends BaseValue implements IBindableValue {
   eval(_scope: IScope): TValueInstructions {
     return [this, []];
   }
+  consume(_scope: IScope): TValueInstructions {
+    return [this, []];
+  }
   toString() {
     return JSON.stringify(this.data);
   }

--- a/compiler/src/values/ObjectValue.ts
+++ b/compiler/src/values/ObjectValue.ts
@@ -15,6 +15,7 @@ export interface IObjectValueData extends TOperatorMacroMap {
   [k: string]: IValue | undefined;
   $get?: MacroFunction<IValue>;
   $eval?: MacroFunction<IValue>;
+  $consume?: MacroFunction<IValue>;
 }
 export class ObjectValue extends VoidValue {
   constant = true;
@@ -48,7 +49,13 @@ export class ObjectValue extends VoidValue {
     if (!$eval) return [this, []];
     return $eval.call(scope, []);
   }
-
+  consume(scope: IScope): TValueInstructions {
+    const { $consume } = this.data;
+    if ($consume) return $consume.call(scope, []);
+    const [res, resInst] = this.eval(scope);
+    res.ensureOwned();
+    return [res, resInst];
+  }
   call(scope: IScope, args: IValue[]): TValueInstructions<IValue | null> {
     const { $call } = this.data;
     if (!$call) return super.call(scope, args);

--- a/compiler/src/values/ObjectValue.ts
+++ b/compiler/src/values/ObjectValue.ts
@@ -2,6 +2,7 @@ import { CompilerError } from "../CompilerError";
 import { MacroFunction } from "../macros";
 import { operators } from "../operators";
 import {
+  IOwnedValue,
   IScope,
   IValue,
   TOperatorMacroMap,
@@ -52,9 +53,11 @@ export class ObjectValue extends VoidValue {
   consume(scope: IScope): TValueInstructions {
     const { $consume } = this.data;
     if ($consume) return $consume.call(scope, []);
-    const [res, resInst] = this.eval(scope);
+    const result = this.eval(scope);
+    // required by typescript
+    const res: IValue = result[0];
     res.ensureOwned();
-    return [res, resInst];
+    return result;
   }
   call(scope: IScope, args: IValue[]): TValueInstructions<IValue | null> {
     const { $call } = this.data;
@@ -62,7 +65,7 @@ export class ObjectValue extends VoidValue {
     return $call.call(scope, args);
   }
 
-  ensureOwned(): void {
+  ensureOwned(): asserts this is IOwnedValue {
     this.owner ??= new ValueOwner({ scope: this.scope, value: this });
   }
 }

--- a/compiler/src/values/StoreValue.ts
+++ b/compiler/src/values/StoreValue.ts
@@ -2,7 +2,7 @@ import { BaseValue, LiteralValue } from ".";
 import { CompilerError } from "../CompilerError";
 import { SetInstruction } from "../instructions";
 import { IScope, IValue, TValueInstructions } from "../types";
-import { deepEval, discardedName } from "../utils";
+import { discardedName } from "../utils";
 
 /**
  * `StoreValue` represents values unknown at compile time,
@@ -28,7 +28,7 @@ export class StoreValue extends BaseValue implements IValue {
       else value.owner.moveInto(this.owner);
       if (value instanceof StoreValue) return [this, []];
     }
-    const [evalValue, evalInst] = deepEval(scope, value);
+    const [evalValue, evalInst] = value.consume(scope);
     return [this, [...evalInst, new SetInstruction(this, evalValue)]];
   }
   eval(_scope: IScope): TValueInstructions {

--- a/compiler/src/values/StoreValue.ts
+++ b/compiler/src/values/StoreValue.ts
@@ -32,6 +32,9 @@ export class StoreValue extends BaseValue implements IValue {
     return [this, [...evalInst, new SetInstruction(this, evalValue)]];
   }
   eval(_scope: IScope): TValueInstructions {
+    return [this, []];
+  }
+  consume(_scope: IScope): TValueInstructions {
     this.ensureOwned();
     return [this, []];
   }

--- a/compiler/src/values/VoidValue.ts
+++ b/compiler/src/values/VoidValue.ts
@@ -16,6 +16,9 @@ export class VoidValue implements IValue {
   constructor(scope: IScope) {
     this.scope = scope;
   }
+  consume(_scope: IScope): TValueInstructions<IValue> {
+    throw new CompilerError(`${this} cannot be consumed.`);
+  }
   eval(_scope: IScope): TValueInstructions {
     throw new CompilerError(`${this} cannot eval.`);
   }

--- a/compiler/src/values/VoidValue.ts
+++ b/compiler/src/values/VoidValue.ts
@@ -16,11 +16,11 @@ export class VoidValue implements IValue {
   constructor(scope: IScope) {
     this.scope = scope;
   }
-  consume(_scope: IScope): TValueInstructions<IValue> {
-    throw new CompilerError(`${this} cannot be consumed.`);
-  }
   eval(_scope: IScope): TValueInstructions {
     throw new CompilerError(`${this} cannot eval.`);
+  }
+  consume(_scope: IScope): TValueInstructions<IValue> {
+    throw new CompilerError(`${this} cannot be consumed.`);
   }
   call(_scope: IScope, _args: IValue[]): TValueInstructions<IValue | null> {
     throw new CompilerError(`${this} cannot call.`);


### PR DESCRIPTION
Adds a `consume` method to the `IValue` interface and a `handleConsume` method to the `Compiler` class, this allows a finer control over when values should have temporary owners independently of when they are evaluated.