### PR TITLE
Fix return value of `unitLocate`

### DIFF
--- a/compiler/src/macros/commands/UnitLocate.ts
+++ b/compiler/src/macros/commands/UnitLocate.ts
@@ -77,7 +77,7 @@ export class UnitLocate extends MacroFunction {
           outFound,
           outX,
           outY,
-          ...(find.data === "ore" ? [outBuilding] : []),
+          ...(find.data !== "ore" ? [outBuilding] : []),
         ]),
         [new InstructionBase("ulocate", ...inputArgs, ...outArgs)],
       ];


### PR DESCRIPTION
I can't believe I inverted the condition of the array spread