### PR TITLE
Log errors that are not compiler errors

### DIFF
--- a/compiler/src/bin.ts
+++ b/compiler/src/bin.ts
@@ -41,7 +41,11 @@ yargs(hideBin(process.argv))
       const code = readFileSync(path, "utf8");
       const [output, error, [node]] = compiler.compile(code);
       if (error) {
-        let start = (error as CompilerError).loc as {
+        if (!(error instanceof CompilerError)) {
+          console.error(error);
+          return;
+        }
+        let start = error.loc as {
           line: number;
           column: number;
         };


### PR DESCRIPTION
This will make errors that are not instances of `CompilerError` be logged to the console. This ensures that we only read the location of actual compiler errors throwed by the compiler, and not bugs.