### PR TITLE
Store assignment optimization

### DIFF
--- a/compiler/src/types.ts
+++ b/compiler/src/types.ts
@@ -47,7 +47,7 @@ export interface IValueOwner<T extends IValue = IValue> {
   value: T;
   identifier?: string;
   name: string;
-  temporary: boolean;
+  persistent: boolean;
   own(target: T): void;
   replace(target: T): void;
   /** Moves all values owned by `this` into `owner` */

--- a/compiler/src/values/FunctionValue.ts
+++ b/compiler/src/values/FunctionValue.ts
@@ -161,10 +161,12 @@ export class FunctionValue extends VoidValue implements IFunctionValue {
     const fnScope = this.childScope.copy();
     // hard set variables within the function scope
     this.paramOwners.forEach((owner, i) => {
+      const value = args[i];
+      if (!value.owner?.persistent) owner.own(value);
       fnScope.hardSet(
         new ValueOwner({
           scope: fnScope,
-          value: args[i],
+          value,
           identifier: owner.identifier,
           name: owner.name,
         })

--- a/compiler/src/values/StoreValue.ts
+++ b/compiler/src/values/StoreValue.ts
@@ -23,6 +23,8 @@ export class StoreValue extends BaseValue implements IValue {
       throw new CompilerError(`Cannot assign to unmutable store '${this}'.`);
     if (!this.owner)
       throw new CompilerError(`Cannot assign to temporary value`);
+    if (this.owner === value.owner && value instanceof StoreValue)
+      return [this, []];
     if (!value.owner?.persistent) {
       if (!value.owner) this.owner.own(value);
       else value.owner.moveInto(this.owner);

--- a/compiler/src/values/StoreValue.ts
+++ b/compiler/src/values/StoreValue.ts
@@ -23,7 +23,7 @@ export class StoreValue extends BaseValue implements IValue {
       throw new CompilerError(`Cannot assign to unmutable store '${this}'.`);
     if (!this.owner)
       throw new CompilerError(`Cannot assign to temporary value`);
-    if (!value.owner || value.owner.temporary) {
+    if (!value.owner?.persistent) {
       if (!value.owner) this.owner.own(value);
       else value.owner.moveInto(this.owner);
       if (value instanceof StoreValue) return [this, []];

--- a/compiler/src/values/ValueOwner.ts
+++ b/compiler/src/values/ValueOwner.ts
@@ -19,7 +19,7 @@ export class ValueOwner<T extends IValue = IValue> implements IValueOwner<T> {
   identifier?: string;
   /** The name that the variable will have during transpilation to mlog */
   name: string;
-  temporary: boolean;
+  persistent: boolean;
   /**
    * Creates a new `ValueOwner`, if `value` is already owned,
    * `this` will be aliased to `value`, else `this` will own `value`
@@ -36,9 +36,9 @@ export class ValueOwner<T extends IValue = IValue> implements IValueOwner<T> {
     this.value = value;
     this.identifier = identifier;
     this.name = name ?? scope.makeTempName();
-    this.temporary = !name;
+    this.persistent = !!name;
     this.owned = new Set();
-    if (!value.owner || value.owner.temporary) this.own(value);
+    if (!value.owner?.persistent) this.own(value);
   }
 
   own(target: T): void {


### PR DESCRIPTION
Dedupes self assignments on stores. Mainly affects how inline function calls behave with temporary expressions as parameters.

