### PR TITLE
Fix usage of consume

### DIFF
--- a/compiler/src/handlers/CallExpression.ts
+++ b/compiler/src/handlers/CallExpression.ts
@@ -14,7 +14,7 @@ export const CallExpression: THandler<IValue | null> = (
     return v;
   });
 
-  const [callee, calleeInst] = c.handleEval(scope, node.callee);
+  const [callee, calleeInst] = c.handleConsume(scope, node.callee);
   inst.push(...calleeInst);
 
   const [callValue, callInst] = callee.call(scope, args);

--- a/compiler/src/handlers/Object.ts
+++ b/compiler/src/handlers/Object.ts
@@ -58,10 +58,10 @@ export const MemberExpression: THandler = (
   scope,
   node: es.MemberExpression
 ) => {
-  const [obj, objInst] = c.handleEval(scope, node.object);
+  const [obj, objInst] = c.handleConsume(scope, node.object);
 
   const [prop, propInst] = node.computed
-    ? c.handleEval(scope, node.property)
+    ? c.handleConsume(scope, node.property)
     : [new LiteralValue(scope, (node.property as es.Identifier).name), []];
 
   const [got, gotInst] = obj.get(scope, prop);

--- a/compiler/src/handlers/OperationExpressions.ts
+++ b/compiler/src/handlers/OperationExpressions.ts
@@ -33,6 +33,7 @@ export const AssignmentExpression: THandler = (
   }
 ) => {
   const [left, leftInst] = c.handle(scope, node.left);
+  // doesn't need to consume because the operators already do that
   const [right, rightInst] = c.handleEval(scope, node.right);
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const [op, opInst] = left![node.operator](scope, right);

--- a/compiler/src/handlers/TemplateExpression.ts
+++ b/compiler/src/handlers/TemplateExpression.ts
@@ -9,7 +9,7 @@ export const TemplateLiteral: THandler<null> = (
   const args: (string | IValue)[] = [];
   const inst: IInstruction[] = [];
   node.expressions.forEach((expression, i) => {
-    const [v, vi] = c.handleEval(scope, expression);
+    const [v, vi] = c.handleConsume(scope, expression);
     inst.push(...vi);
     args.push(node.quasis[i].value.raw, v);
   });

--- a/compiler/src/macros/Function.ts
+++ b/compiler/src/macros/Function.ts
@@ -21,4 +21,7 @@ export class MacroFunction<
   eval(_scope: IScope): TValueInstructions {
     return [this, []];
   }
+  consume(_scope: IScope): TValueInstructions {
+    return [this, []];
+  }
 }

--- a/compiler/src/values/FunctionValue.ts
+++ b/compiler/src/values/FunctionValue.ts
@@ -216,7 +216,6 @@ export class FunctionValue extends VoidValue implements IFunctionValue {
   }
 
   consume(_scope: IScope): TValueInstructions {
-    this.ensureOwned();
     return [this, []];
   }
 }

--- a/compiler/src/values/FunctionValue.ts
+++ b/compiler/src/values/FunctionValue.ts
@@ -214,4 +214,9 @@ export class FunctionValue extends VoidValue implements IFunctionValue {
   eval(_scope: IScope): TValueInstructions {
     return [this, []];
   }
+
+  consume(_scope: IScope): TValueInstructions {
+    this.ensureOwned();
+    return [this, []];
+  }
 }

--- a/compiler/test/in/template_strings.js
+++ b/compiler/test/in/template_strings.js
@@ -1,6 +1,12 @@
 const turret = getBuilding("cyclone1");
 
+let first = 10;
+let second = 0.2;
+
 // raw use of radar
 `radar player enemy any distance ${turret} 1 radarResult`;
 
+// temporary values should work too
+`op mul foo ${first + second} 2`;
 print(getVar("radarResult"));
+print(getVar("foo"));

--- a/compiler/test/out/template_strings.mlog
+++ b/compiler/test/out/template_strings.mlog
@@ -1,3 +1,8 @@
+set first 10
+set second 0.2
 radar player enemy any distance cyclone1 1 radarResult
+op add &t0 first second
+op mul foo &t0 2
 print radarResult
+print foo
 end


### PR DESCRIPTION
The `handleConsume` method from the compiler was not being used on all the places it should, so this pull request fixes that.