### PR TITLE
Fix error message location of some handlers

### DIFF
--- a/compiler/src/handlers/Object.ts
+++ b/compiler/src/handlers/Object.ts
@@ -12,9 +12,9 @@ export const ObjectExpression: THandler = (
   const inst = [];
   for (const prop of node.properties) {
     if (prop.type === "SpreadElement")
-      throw new CompilerError("Cannot handle spread element");
+      throw new CompilerError("Cannot handle spread element", [prop]);
     if (prop.computed)
-      throw new CompilerError("Cannot handle computed property.");
+      throw new CompilerError("Cannot handle computed property.", [prop]);
     const { key } = prop;
     const value = prop.type === "ObjectProperty" ? prop.value : prop;
     let index: string;
@@ -23,7 +23,9 @@ export const ObjectExpression: THandler = (
     } else if (key.type === "StringLiteral" || key.type === "NumericLiteral") {
       index = `${key.value}`;
     } else {
-      throw new CompilerError(`Unsupported object key type: ${key.type}`);
+      throw new CompilerError(`Unsupported object key type: ${key.type}`, [
+        key,
+      ]);
     }
     const [member, memberInst] = c.handleEval(scope, value);
     const owner = new ValueOwner({

--- a/compiler/src/handlers/VariableDeclaration.ts
+++ b/compiler/src/handlers/VariableDeclaration.ts
@@ -81,14 +81,16 @@ export const VariableDeclarator: THandler<IValue | null> = (
         if (!element) continue;
         if (element.type !== "Identifier") {
           throw new CompilerError(
-            "Array destructuring expression can only have empty items or identifiers"
+            "Array destructuring expression can only have empty items or identifiers",
+            [element]
           );
         }
 
         const val = init.data[i];
         if (!val)
           throw new CompilerError(
-            `The property "${i}" does not exist on the target object`
+            `The property "${i}" does not exist on the target object`,
+            [element]
           );
         const owner = new ValueOwner({
           scope,


### PR DESCRIPTION
This pull request fixes issues with the location of the error messages on object expressions and variable declarations.

Here is a demonstration. The following code fails differently on the current and new versions.


```js
const stuff = {
  one: 1,
  two: 2,
  [`forbidden key`]: 3,
};
```
Before:
```
  1 | const stuff = {
                    ^ Cannot handle computed property.
  2 |   one: 1,
  3 |   two: 2,
  4 |   [`forbidden key`]: 3,
  5 | };
  6 | 
```

After:
```
  2 |   one: 1,
  3 |   two: 2,
  4 |   [`forbidden key`]: 3,
        ^ Cannot handle computed property.
  5 | };
  6 | 
```

A subtle but important difference.