### PR TITLE
Make the line index of the output editor start at 0

### DIFF
--- a/editor/App.tsx
+++ b/editor/App.tsx
@@ -62,7 +62,10 @@ export function App() {
           onMount={onMount}
           value={code}
         />
-        <Editor value={compiled} options={{ readOnly: true }}></Editor>
+        <Editor
+          value={compiled}
+          options={{ readOnly: true, lineNumbers: n => `${n - 1}` }}
+        ></Editor>
       </SplitPane>
     </Fragment>
   );


### PR DESCRIPTION
This makes it easier for people to read the output code and know where jumps go to