### PR TITLE
Update variable name handling

### DIFF
--- a/compiler/src/Scope.ts
+++ b/compiler/src/Scope.ts
@@ -110,25 +110,4 @@ export class Scope implements IScope {
     this.ntemp++;
     return result;
   }
-
-  formatName(name: string): string {
-    if (this.name) return `${name}:${this.name}`;
-    const depth = nameDepth(this, name);
-    if (depth) return `${name}$${depth}`;
-    return name;
-  }
-}
-
-/**
- * Gets the name depth of a variable, it indicates how many variables
- * with the same name exist on the parent unnamed scopes
- */
-function nameDepth(scope: IScope, name: string): number {
-  let depth = 0;
-  let current: IScope | null = scope.parent;
-  while (current != null && !current.name) {
-    if (name in current.data) depth++;
-    current = current.parent;
-  }
-  return depth;
 }

--- a/compiler/src/handlers/Function.ts
+++ b/compiler/src/handlers/Function.ts
@@ -46,7 +46,7 @@ export const FunctionDeclaration: THandler = (
   node: es.FunctionDeclaration
 ) => {
   const identifier = (node.id as es.Identifier).name;
-  const name = c.compactNames ? nodeName(node) : scope.formatName(identifier);
+  const name = nodeName(node, !c.compactNames && identifier);
   const functionIns = handleFunctionNode(c, scope, node);
   const owner = new ValueOwner({
     scope,

--- a/compiler/src/handlers/Typescript.ts
+++ b/compiler/src/handlers/Typescript.ts
@@ -66,7 +66,7 @@ export const TSEnumDeclaration: THandler<null> = (
       value: new ObjectValue(scope, data),
       constant: true,
       identifier: node.id.name,
-      name: c.compactNames ? nodeName(node) : scope.formatName(node.id.name),
+      name: nodeName(node, !c.compactNames && node.id.name),
     })
   );
 

--- a/compiler/src/handlers/VariableDeclaration.ts
+++ b/compiler/src/handlers/VariableDeclaration.ts
@@ -26,9 +26,7 @@ export const VariableDeclarator: THandler<IValue | null> = (
   switch (node.id.type) {
     case "Identifier": {
       const { name: identifier } = node.id;
-      const name = c.compactNames
-        ? nodeName(node)
-        : scope.formatName(identifier);
+      const name = nodeName(node, !c.compactNames && identifier);
       const [init] = valinst;
       if (kind === "const" && !init)
         throw new CompilerError("Constants must be initialized.");
@@ -95,9 +93,7 @@ export const VariableDeclarator: THandler<IValue | null> = (
         const owner = new ValueOwner({
           scope,
           identifier: element.name,
-          name: c.compactNames
-            ? nodeName(element)
-            : scope.formatName(element.name),
+          name: nodeName(element, !c.compactNames && element.name),
           value: val,
           constant: true,
         });

--- a/compiler/src/types.ts
+++ b/compiler/src/types.ts
@@ -99,8 +99,6 @@ export interface IScope {
   copy(): IScope;
   /** Creates a temporary mlog variable name */
   makeTempName(): string;
-  /** Formats the name of a variable to make it unique in the mlog output */
-  formatName(name: string): string;
 }
 
 /**

--- a/compiler/src/utils.ts
+++ b/compiler/src/utils.ts
@@ -7,11 +7,15 @@ export const internalPrefix = "&";
 export const discardedName = `${internalPrefix}_`;
 
 /**
- * Returns a string that has the format: [line]:[column]
+ * Returns a string that has the format: [line]:[column].
+ *
+ * If `name` is provided, and it is a string, the resulting string will
+ * have the format: [name]@[line]:[column].
  */
-export function nodeName(node: es.Node) {
+export function nodeName(node: es.Node, name?: false | string) {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const { line, column } = node.loc!.start;
+  if (typeof name === "string") return `${name}@${line}:${column}`;
   return `${line}:${column}`;
 }
 

--- a/compiler/src/utils.ts
+++ b/compiler/src/utils.ts
@@ -10,12 +10,12 @@ export const discardedName = `${internalPrefix}_`;
  * Returns a string that has the format: [line]:[column].
  *
  * If `name` is provided, and it is a string, the resulting string will
- * have the format: [name]@[line]:[column].
+ * have the format: [name]:[line]:[column].
  */
 export function nodeName(node: es.Node, name?: false | string) {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const { line, column } = node.loc!.start;
-  if (typeof name === "string") return `${name}-${line}:${column}`;
+  if (typeof name === "string") return `${name}:${line}:${column}`;
   return `${line}:${column}`;
 }
 

--- a/compiler/src/utils.ts
+++ b/compiler/src/utils.ts
@@ -15,7 +15,7 @@ export const discardedName = `${internalPrefix}_`;
 export function nodeName(node: es.Node, name?: false | string) {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const { line, column } = node.loc!.start;
-  if (typeof name === "string") return `${name}@${line}:${column}`;
+  if (typeof name === "string") return `${name}-${line}:${column}`;
   return `${line}:${column}`;
 }
 

--- a/compiler/src/values/FunctionValue.ts
+++ b/compiler/src/values/FunctionValue.ts
@@ -74,9 +74,7 @@ export class FunctionValue extends VoidValue implements IFunctionValue {
     this.childScope = this.scope.createFunction(name);
     this.childScope.function = this;
     for (const id of this.params) {
-      const name = this.c.compactNames
-        ? nodeName(id)
-        : this.childScope.formatName(id.name);
+      const name = nodeName(id, !this.c.compactNames && id.name);
       const owner = new ValueOwner({
         scope: this.childScope,
         value: new StoreValue(this.childScope),
@@ -95,9 +93,7 @@ export class FunctionValue extends VoidValue implements IFunctionValue {
     if (this.initialized) return;
     this.initialized = true;
 
-    const name = this.c.compactNames
-      ? nodeName(this.node)
-      : this.scope.formatName(this.owner.name);
+    const name = nodeName(this.node, !this.c.compactNames && this.owner.name);
     this.initScope(name);
 
     this.addr = new LiteralValue(this.childScope, null as never);

--- a/compiler/test/out/branching.mlog
+++ b/compiler/test/out/branching.mlog
@@ -1,5 +1,5 @@
-set i 1
-op greaterThan &t0 i 10
+set i:1:4 1
+op greaterThan &t0 i:1:4 10
 jump 4 equal &t0 0
 print "I will always show up in the code"
 end

--- a/compiler/test/out/buildings.mlog
+++ b/compiler/test/out/buildings.mlog
@@ -1,11 +1,11 @@
-set coolant @cryofluid
+set coolant:2:6 @cryofluid
 sensor &t0 cyclone1 @ammo
 print "current ammo: "
 print &t0
 print "\n"
-sensor &t1 cyclone1 coolant
+sensor &t1 cyclone1 coolant:2:6
 print "amount of "
-print coolant
+print coolant:2:6
 print " : "
 print &t1
 print "\n"

--- a/compiler/test/out/for_loop.mlog
+++ b/compiler/test/out/for_loop.mlog
@@ -1,7 +1,7 @@
-set i 0
-op lessThan &t0 i 100
+set i:1:9 0
+op lessThan &t0 i:1:9 100
 jump 6 equal &t0 0
-print i
-op add i i 1
+print i:1:9
+op add i:1:9 i:1:9 1
 jump 1 always
 end

--- a/compiler/test/out/for_loop_inf.mlog
+++ b/compiler/test/out/for_loop_inf.mlog
@@ -1,6 +1,6 @@
-set i 0
+set i:1:9 0
 jump 5 equal 1 0
-print i
-op add i i 1
+print i:1:9
+op add i:1:9 i:1:9 1
 jump 1 always
 end

--- a/compiler/test/out/functions.mlog
+++ b/compiler/test/out/functions.mlog
@@ -1,38 +1,38 @@
-set type 0
-set a 1
-set b 1
-set type:op type
-set a:op a
-set b:op b
-set &rop 8
+set type:24:4 0
+set a:25:4 1
+set b:26:4 1
+set type:17:12 type:24:4
+set a:17:18 a:25:4
+set b:17:21 b:26:4
+set &rop:17:0:17:0 8
 jump 14 always
-set result &fop
+set result:28:4 &fop:17:0:17:0
 print "Thre result is: "
-print result
+print result:28:4
 print "."
 printflush message1
 end
-op strictEqual &t0:op type:op 0
-jump 20 equal &t0:op 0
-op add &fop a:op b:op
+op strictEqual &t0:op:17:0:17:0 type:17:12 0
+jump 20 equal &t0:op:17:0:17:0 0
+op add &fop:17:0:17:0 a:17:18 b:17:21
 jump 18 always
-set @counter &rop
+set @counter &rop:17:0:17:0
 jump 37 always
-op strictEqual &t1:op type:op 1
-jump 26 equal &t1:op 0
-op sub &fop a:op b:op
+op strictEqual &t1:op:17:0:17:0 type:17:12 1
+jump 26 equal &t1:op:17:0:17:0 0
+op sub &fop:17:0:17:0 a:17:18 b:17:21
 jump 24 always
-set @counter &rop
+set @counter &rop:17:0:17:0
 jump 37 always
-op strictEqual &t2:op type:op 2
-jump 32 equal &t2:op 0
-op mul &fop a:op b:op
+op strictEqual &t2:op:17:0:17:0 type:17:12 2
+jump 32 equal &t2:op:17:0:17:0 0
+op mul &fop:17:0:17:0 a:17:18 b:17:21
 jump 30 always
-set @counter &rop
+set @counter &rop:17:0:17:0
 jump 37 always
-op strictEqual &t3:op type:op 3
-jump 37 equal &t3:op 0
-op div &fop a:op b:op
+op strictEqual &t3:op:17:0:17:0 type:17:12 3
+jump 37 equal &t3:op:17:0:17:0 0
+op div &fop:17:0:17:0 a:17:18 b:17:21
 jump 36 always
-set @counter &rop
-set @counter &rop
+set @counter &rop:17:0:17:0
+set @counter &rop:17:0:17:0

--- a/compiler/test/out/math.mlog
+++ b/compiler/test/out/math.mlog
@@ -1,34 +1,34 @@
-set a 10
-set b 20
-op max &_ a b
-op min &_ a b
-op angle &_ a b
-op len &_ a b
-op noise &_ a b
-op abs &_ a
-op log &_ a
-op log10 &_ a
-op sin &_ a
-op cos &_ a
-op tan &_ a
-op floor &_ a
-op ceil &_ a
-op sqrt &_ a
-op rand &_ a
-set temp 0
-set temp 20
-set temp 10.5
-set temp 62.300527191945
-set temp 22.588713996153036
-op noise temp 10.5 20
-set temp 10.5
-set temp 2.3513752571634776
-set temp 1.021189299069938
-set temp -0.87969575997167
-set temp -0.47553692799599256
-set temp 1.8498999934219273
-set temp 10
-set temp 11
-set temp 3.24037034920393
-op rand temp 10.5
+set a:2:4 10
+set b:3:4 20
+op max &_ a:2:4 b:3:4
+op min &_ a:2:4 b:3:4
+op angle &_ a:2:4 b:3:4
+op len &_ a:2:4 b:3:4
+op noise &_ a:2:4 b:3:4
+op abs &_ a:2:4
+op log &_ a:2:4
+op log10 &_ a:2:4
+op sin &_ a:2:4
+op cos &_ a:2:4
+op tan &_ a:2:4
+op floor &_ a:2:4
+op ceil &_ a:2:4
+op sqrt &_ a:2:4
+op rand &_ a:2:4
+set temp:23:4 0
+set temp:23:4 20
+set temp:23:4 10.5
+set temp:23:4 62.300527191945
+set temp:23:4 22.588713996153036
+op noise temp:23:4 10.5 20
+set temp:23:4 10.5
+set temp:23:4 2.3513752571634776
+set temp:23:4 1.021189299069938
+set temp:23:4 -0.87969575997167
+set temp:23:4 -0.47553692799599256
+set temp:23:4 1.8498999934219273
+set temp:23:4 10
+set temp:23:4 11
+set temp:23:4 3.24037034920393
+op rand temp:23:4 10.5
 end

--- a/compiler/test/out/memory.mlog
+++ b/compiler/test/out/memory.mlog
@@ -7,9 +7,9 @@ jump 9 equal &t1 0
 write 1 bank1 0
 print "Processor intialized"
 jump 16 always
-read runs bank1 1
+read runs:11:6 bank1 1
 print "This code has run "
-print runs
+print runs:11:6
 print " time(s)"
 read &t2 bank1 1
 op add &t2 &t2 1

--- a/compiler/test/out/scopes.mlog
+++ b/compiler/test/out/scopes.mlog
@@ -1,5 +1,5 @@
-set foo 10
-set foo$1 15
-print foo$1
-print foo
+set foo:1:4 10
+set foo:4:6 15
+print foo:4:6
+print foo:1:4
 end

--- a/compiler/test/out/template_strings.mlog
+++ b/compiler/test/out/template_strings.mlog
@@ -1,7 +1,7 @@
-set first 10
-set second 0.2
+set first:3:4 10
+set second:4:4 0.2
 radar player enemy any distance cyclone1 1 radarResult
-op add &t0 first second
+op add &t0 first:3:4 second:4:4
 op mul foo &t0 2
 print radarResult
 print foo

--- a/compiler/test/out/unit_commands.mlog
+++ b/compiler/test/out/unit_commands.mlog
@@ -7,9 +7,9 @@ ucontrol getBlock 0 0 &_ &_ 0
 ucontrol idle
 ucontrol itemDrop @air 100
 ucontrol itemTake shard1 @copper 10
-ucontrol within 1 2 10 isWithin 0
-print isWithin
-ucontrol getBlock 10 20 type building 0
-print type
-print building
+ucontrol within 1 2 10 isWithin:15:6 0
+print isWithin:15:6
+ucontrol getBlock 10 20 type:18:7 building:18:13 0
+print type:18:7
+print building:18:13
 end

--- a/compiler/test/out/unit_macro.mlog
+++ b/compiler/test/out/unit_macro.mlog
@@ -9,17 +9,17 @@ sensor &t2 @unit @health
 print "health: "
 print &t2
 print "\n"
-set item @copper
-sensor &t3 @unit item
+set item:10:4 @copper
+sensor &t3 @unit item:10:4
 print "amount of "
-print item
+print item:10:4
 print " : "
 print &t3
 printflush message1
-radar enemy any any distance cyclone1 1 unitA
-uradar enemy flying any distance 0 1 unitB
-sensor &t4 unitA @health
-sensor &t5 unitB @health
+radar enemy any any distance cyclone1 1 unitA:14:6
+uradar enemy flying any distance 0 1 unitB:22:6
+sensor &t4 unitA:14:6 @health
+sensor &t5 unitB:22:6 @health
 print &t4
 print &t5
 end

--- a/compiler/test/out/while_loop.mlog
+++ b/compiler/test/out/while_loop.mlog
@@ -1,7 +1,7 @@
-set i 0
-op lessThan &t0 i 100
+set i:1:4 0
+op lessThan &t0 i:1:4 100
 jump 6 equal &t0 0
-print i
-op add i i 1
+print i:1:4
+op add i:1:4 i:1:4 1
 jump 1 always
 end

--- a/compiler/test/out/while_loop_break.mlog
+++ b/compiler/test/out/while_loop_break.mlog
@@ -1,10 +1,10 @@
-set i 0
-op lessThan &t0 i 100
+set i:1:4 0
+op lessThan &t0 i:1:4 100
 jump 9 equal &t0 0
 op rand &t1
 op greaterThan &t1 &t1 0.5
 jump 7 equal &t1 0
 jump 9 always
-op add i i 1
+op add i:1:4 i:1:4 1
 jump 1 always
 end


### PR DESCRIPTION
Now the code output with `--compact-names` will contain variables with the following name scheme:
`[name]:[line]:[column]` (like `foo:4:6`). This makes the names automatically unique and also makes the logic for getting node names simpler