### PR TITLE
Destructuring fixes

### DIFF
--- a/compiler/src/values/DestructuringValue.ts
+++ b/compiler/src/values/DestructuringValue.ts
@@ -1,5 +1,5 @@
 import { IInstruction, IScope, IValue, TValueInstructions } from "../types";
-import { ObjectValue } from "./ObjectValue";
+import { VoidValue } from "./VoidValue";
 
 /**
  * Specific case class, required on the ArrayPattern and ObjectPattern handlers
@@ -8,7 +8,9 @@ import { ObjectValue } from "./ObjectValue";
  * When it is assign a value, it will get it's own properties and recursively assign
  * each of them to their counterparts on the right hand value.
  */
-export class DestructuringValue extends ObjectValue {
+export class DestructuringValue extends VoidValue {
+  macro = true;
+
   constructor(scope: IScope, public members: Map<IValue, IValue>) {
     super(scope);
   }
@@ -22,5 +24,13 @@ export class DestructuringValue extends ObjectValue {
       inst.push(...value["="](scope, item)[1]);
     }
     return [right, inst];
+  }
+
+  eval(_scope: IScope): TValueInstructions<IValue> {
+    return [this, []];
+  }
+
+  consume(_scope: IScope): TValueInstructions<IValue> {
+    return [this, []];
   }
 }

--- a/compiler/test/in/object_des.js
+++ b/compiler/test/in/object_des.js
@@ -1,3 +1,5 @@
+const mem = new Memory(getBuilding("cell1"));
+
 let { x, y, health } = getBuilding("cyclone1");
 
 const [, , , { type: coreType }] = unitLocate("building", "core", true);
@@ -6,21 +8,21 @@ print(x, y, health, coreType);
 printFlush(getBuilding("message1"));
 
 // test with objetc macro
-({ x, y, health } = { x: 10, y: 20, health: 200 });
+({ x, y, health, first: mem[0] } = { x: 10, y: 20, health: 200, first: 20 });
 
 // test with nested object macro
 ({
   x,
   a: {
     y,
-    b: [health],
+    b: [health, mem[0]],
   },
 } = {
   x: 30,
   a: {
     y: 40,
-    b: [500],
+    b: [500, 50],
   },
 });
 
-print(x, y, health);
+print(x, y, health, mem[0]);

--- a/compiler/test/out/object_des.mlog
+++ b/compiler/test/out/object_des.mlog
@@ -1,20 +1,24 @@
-sensor x:1:6 cyclone1 @x
-sensor y:1:9 cyclone1 @y
-sensor health:1:12 cyclone1 @health
+sensor x:3:6 cyclone1 @x
+sensor y:3:9 cyclone1 @y
+sensor health:3:12 cyclone1 @health
 ulocate building core 1 @copper &_ &_ &_ &t0
-sensor coreType:3:21 &t0 @type
-print x:1:6
-print y:1:9
-print health:1:12
-print coreType:3:21
+sensor coreType:5:21 &t0 @type
+print x:3:6
+print y:3:9
+print health:3:12
+print coreType:5:21
 printflush message1
-set x:1:6 10
-set y:1:9 20
-set health:1:12 200
-set x:1:6 30
-set y:1:9 40
-set health:1:12 500
-print x:1:6
-print y:1:9
-print health:1:12
+set x:3:6 10
+set y:3:9 20
+set health:3:12 200
+write 20 cell1 0
+set x:3:6 30
+set y:3:9 40
+set health:3:12 500
+write 50 cell1 0
+read &t9 cell1 0
+print x:3:6
+print y:3:9
+print health:3:12
+print &t9
 end


### PR DESCRIPTION
Changes three things:
- Now the `DestructuringValue` class directly extends `VoidValue` instead if `ObjectValue`
- Now the keys of a destructuring expression are consumed, makes things with temporary values on the keys work
- Now the values to be written are no longer evaluated, this makes some macros (specially the memory one) behave correctly in that context