### PR TITLE
More syntax docs

### DIFF
--- a/compiler/doc/index.html
+++ b/compiler/doc/index.html
@@ -35,6 +35,10 @@
   <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
   <script src="https://unpkg.com/docsify-copy-code@2"></script>
   <script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>
+  <!-- Prism code highlighting -->
+  <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-bash.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-typescript.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-json.min.js"></script>
 </body>
 
 </html>

--- a/compiler/doc/syntax-support.md
+++ b/compiler/doc/syntax-support.md
@@ -132,12 +132,48 @@ Behavior:
 
 - Supports `break` and `continue` statements
 
+### Destructuring
+
+You can use destructuring to assign or declare variables.
+
+It is treated by the compiler as a sintactic sugar for assignments/declarations that are based on object properties. The following examples have exactly the same output:
+
+```js
+const turret = getBuilding("cyclone1");
+const { x, y, health } = turret;
+```
+
+```js
+const turret = getBuilding("cyclone1");
+const x = turret.x;
+const y = turret.y;
+const health = turret.health;
+```
+
+Behavior:
+
+- Assigns each destructured expression in the declaration order
+- Destructuring expressions CAN be nested.
+
+```js
+const [found, x, y, { totalItems }] = unitLocate("building", "core", false);
+```
+
+Limitations:
+
+- Because this is just syntactic sugar to make multiple assignments, you can't do variable swaps.
+
+```js
+// WARNING: does not work
+[a, b] = [b, a];
+```
+
 ### Template strings
 
 Template strings in javascript allow you to interpolate values with strings in
 a convenient way.
 
-But since the mlog runtime doesn't support string contenation template are used to
+But since the mlog runtime doesn't support string contenation template strings are used to
 inline mlog code.
 
 The following has it's last line inlined onto the output.

--- a/compiler/doc/syntax-support.md
+++ b/compiler/doc/syntax-support.md
@@ -217,3 +217,13 @@ Behavior:
 Limitations:
 
 - All enums must be `const`, since dynamic objects are not supported in the mlog runtime
+
+### Type casts
+
+You can type cast variables to narrow the type of a variable.
+
+Note that the mlogjs compiler does not take in account for the typescript types of variables and expressions.
+
+### Types/interfaces
+
+You can declare custom type aliases and interfaces. Since the compiler does not perform typescript's type checking, it will simply ignore these kinds of declarations.

--- a/compiler/doc/syntax-support.md
+++ b/compiler/doc/syntax-support.md
@@ -227,3 +227,7 @@ Note that the mlogjs compiler does not take in account for the typescript types 
 ### Types/interfaces
 
 You can declare custom type aliases and interfaces. Since the compiler does not perform typescript's type checking, it will simply ignore these kinds of declarations.
+
+### Non null assertions
+
+Again, this one is ignored by the compiler, use it to make typescript happy, though most of the time you should check nullable variables is before using them.

--- a/compiler/doc/syntax-support.md
+++ b/compiler/doc/syntax-support.md
@@ -132,6 +132,31 @@ Behavior:
 
 - Supports `break` and `continue` statements
 
+### Math and related operators
+
+All the mathematical operators for numbers are supported and will be transpiled into mlog code.
+
+But the `Math` object has been modified to match the other math functions
+available on the mlog runtime. They are listed bellow:
+
+- `abs` - Absolute value of a number
+- `angle` - Angle of a vector in degrees
+- `ceil` - Rounds the number to the closest bigger integer
+- `cos` - Cosine of an angle in degrees
+- `floor` - Rounds the number to the closest smaller integer
+- `len` - Length of a vector
+- `log` - Natural logarithm of a number
+- `log10` - Base 10 logarithm of a number
+- `max` - Returns the biggest of two values
+- `min` - Returns the smallest of two values
+- `noise` - 2D simplex noise
+- `rand` - Random number between 0 (inclusive) and the specified number (exclusive)
+- `sin` - Sine of an angle in degrees
+- `sqrt` - Square root of a number
+- `tan` - Tangent of an angle in degrees
+
+Check out the [online editor](https://mlogjs.github.io/mlogjs/editor/) to see how each one works!
+
 ### Destructuring
 
 You can use destructuring to assign or declare variables.

--- a/compiler/doc/syntax-support.md
+++ b/compiler/doc/syntax-support.md
@@ -157,6 +157,31 @@ available on the mlog runtime. They are listed bellow:
 
 Check out the [online editor](https://mlogjs.github.io/mlogjs/editor/) to see how each one works!
 
+### Logical operators
+
+The logical operators `&&` (and) and `||` (or) are supported, although they DO NOT short-circuit. See [What is short-circuiting?](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND#short-circuit_evaluation)
+
+Another caution you must take is that differently from regular javascript, these operators will ALWAYS return boolean values, which means that code like this will not work.
+
+```js
+// WARNING: does not work
+// first: both expressions are evaluated because there is no
+// short circuiting
+//
+// second: the final value will be a boolean, not
+// whathever object getSomething returns
+let foo = isEnabled && getSomething();
+```
+
+Behavior:
+
+- The operators evaluate all of the expressions and return a boolean value
+
+Limitations:
+
+- No short-circuiting support
+- These expressions cannot return anything other than a boolean
+
 ### Destructuring
 
 You can use destructuring to assign or declare variables.

--- a/compiler/doc/syntax-support.md
+++ b/compiler/doc/syntax-support.md
@@ -230,4 +230,4 @@ You can declare custom type aliases and interfaces. Since the compiler does not 
 
 ### Non null assertions
 
-Again, this one is ignored by the compiler, use it to make typescript happy, though most of the time you should check nullable variables is before using them.
+Again, this one is ignored by the compiler, use it to make typescript happy, though most of the time you should check if nullable variables are `null` before using them.


### PR DESCRIPTION
Adds some extra syntax docs for the following features of the compiler:
- `Math` macro
- Destructuring
- Logical operators
- Non null assertions (typescript)
- Type casts (typescript)

And also adds syntax highlighting for typescript and json.