### PR TITLE
Add support for `@tick` and `@time`

### DIFF
--- a/compiler/lib/globals.d.ts
+++ b/compiler/lib/globals.d.ts
@@ -28,6 +28,10 @@ interface Vars {
   readonly ipt: number;
   /** The unit bound to this processor */
   readonly unit: AnyUnit;
+  /** The amount of ticks that happened since the map started*/
+  readonly tick: number;
+  /** The current UNIX timestamp in milliseconds */
+  readonly time: number;
   /** Total amount of items existent, can be used to check if an ID is valid*/
   readonly itemCount: number;
   /** Total amount of liquids existent, can be used to check if an ID is valid*/


### PR DESCRIPTION
Quality of life improvement, lets users use those globals via the `Vars` namespace.