### PR TITLE
Fix the mlog name of function variables

### DIFF
--- a/compiler/src/values/FunctionValue.ts
+++ b/compiler/src/values/FunctionValue.ts
@@ -93,7 +93,7 @@ export class FunctionValue extends VoidValue implements IFunctionValue {
     if (this.initialized) return;
     this.initialized = true;
 
-    const name = nodeName(this.node, !this.c.compactNames && this.owner.name);
+    const { name } = this.owner;
     this.initScope(name);
 
     this.addr = new LiteralValue(this.childScope, null as never);

--- a/compiler/test/out/functions.mlog
+++ b/compiler/test/out/functions.mlog
@@ -4,30 +4,30 @@ set b:26:4 1
 set type:17:12 type:24:4
 set a:17:18 a:25:4
 set b:17:21 b:26:4
-set &rop:17:0:17:0 8
+set &rop:17:0 8
 jump 14 always
-set result:28:4 &fop:17:0:17:0
+set result:28:4 &fop:17:0
 print "Thre result is: "
 print result:28:4
 print "."
 printflush message1
 end
-op strictEqual &t0:op:17:0:17:0 type:17:12 0
-jump 19 equal &t0:op:17:0:17:0 0
-op add &fop:17:0:17:0 a:17:18 b:17:21
-set @counter &rop:17:0:17:0
+op strictEqual &t0:op:17:0 type:17:12 0
+jump 19 equal &t0:op:17:0 0
+op add &fop:17:0 a:17:18 b:17:21
+set @counter &rop:17:0
 jump 33 always
-op strictEqual &t1:op:17:0:17:0 type:17:12 1
-jump 24 equal &t1:op:17:0:17:0 0
-op sub &fop:17:0:17:0 a:17:18 b:17:21
-set @counter &rop:17:0:17:0
+op strictEqual &t1:op:17:0 type:17:12 1
+jump 24 equal &t1:op:17:0 0
+op sub &fop:17:0 a:17:18 b:17:21
+set @counter &rop:17:0
 jump 33 always
-op strictEqual &t2:op:17:0:17:0 type:17:12 2
-jump 29 equal &t2:op:17:0:17:0 0
-op mul &fop:17:0:17:0 a:17:18 b:17:21
-set @counter &rop:17:0:17:0
+op strictEqual &t2:op:17:0 type:17:12 2
+jump 29 equal &t2:op:17:0 0
+op mul &fop:17:0 a:17:18 b:17:21
+set @counter &rop:17:0
 jump 33 always
-op strictEqual &t3:op:17:0:17:0 type:17:12 3
-jump 33 equal &t3:op:17:0:17:0 0
-op div &fop:17:0:17:0 a:17:18 b:17:21
-set @counter &rop:17:0:17:0
+op strictEqual &t3:op:17:0 type:17:12 3
+jump 33 equal &t3:op:17:0 0
+op div &fop:17:0 a:17:18 b:17:21
+set @counter &rop:17:0

--- a/compiler/test/out/object_des.mlog
+++ b/compiler/test/out/object_des.mlog
@@ -21,7 +21,7 @@ print x:3:6
 print y:3:9
 print health:3:12
 print &t9
-ulocate building core 1 @copper &_ &_ &_ &t0:computed:31:6:31:17
-sensor x:3:6 &t0:computed:31:6:31:17 @x
-sensor y:3:9 &t0:computed:31:6:31:17 @y
+ulocate building core 1 @copper &_ &_ &_ &t0:computed:31:6
+sensor x:3:6 &t0:computed:31:6 @x
+sensor y:3:9 &t0:computed:31:6 @y
 end


### PR DESCRIPTION
The names of internal values generated inside functions had two source locations appended at the end.

Bellow is an example with the diff between the compiler outputs:

```ts
function one() {
  print(Vars.itemCount);
  print(Vars.unitCount);
  print(Vars.blockCount);
  print(Vars.unitCount);
  print(Vars.this.type);
}

one();
```
```diff
- set &rone:3:0:3:0 2
+ set &rone:3:0 2
jump 3 always
end
print @itemCount
print @unitCount
print @blockCount
print @unitCount
- sensor &t0:one:3:0:3:0 @this @type
- print &t0:one:3:0:3:0
- set @counter &rone:3:0:3:0
+ sensor &t0:one:3:0 @this @type
+ print &t0:one:3:0
+ set @counter &rone:3:0

```
