### PR TITLE
Fix jsdoc example on senseable value

### DIFF
--- a/compiler/src/values/SenseableValue.ts
+++ b/compiler/src/values/SenseableValue.ts
@@ -21,8 +21,9 @@ const senseableProps = ["controller"];
  * Note that these values are constant by default, so make sure
  * to set that field to `false` if you want them to be assignable. Example:
  * ```
- * const value = new SenseableValue(scope)
- * value.constant = false
+ * const value = assign(new SenseableValue(scope), {
+ *   mutability: EMutability.mutable
+ * })
  * ```
  */
 export class SenseableValue extends StoreValue {


### PR DESCRIPTION
Fixes the jsdoc comment of `SenseableValue`. It became outdated after #59.