### PR TITLE
Expand senseable value uses

### DIFF
--- a/compiler/src/macros/commands/Sensor.ts
+++ b/compiler/src/macros/commands/Sensor.ts
@@ -1,8 +1,9 @@
 import { InstructionBase } from "../../instructions";
 import { MacroFunction } from "..";
-import { IScope } from "../../types";
+import { EMutability, IScope } from "../../types";
 import { SenseableValue, StoreValue } from "../../values";
 import { CompilerError } from "../../CompilerError";
+import { assign } from "../../utils";
 
 export class Sensor extends MacroFunction {
   constructor(scope: IScope) {
@@ -13,7 +14,9 @@ export class Sensor extends MacroFunction {
       if (!(target instanceof SenseableValue))
         throw new CompilerError("The sensor target must be a senseable value");
 
-      const temp = new StoreValue(scope);
+      const temp = assign(new SenseableValue(scope), {
+        mutability: EMutability.readonly,
+      });
       return [temp, [new InstructionBase("sensor", temp, target, property)]];
     });
   }

--- a/compiler/src/values/FunctionValue.ts
+++ b/compiler/src/values/FunctionValue.ts
@@ -78,7 +78,9 @@ export class FunctionValue extends VoidValue implements IFunctionValue {
       const name = nodeName(id, !this.c.compactNames && id.name);
       const owner = new ValueOwner({
         scope: this.childScope,
-        value: new StoreValue(this.childScope),
+        value: assign(new SenseableValue(this.childScope), {
+          mutability: EMutability.mutable,
+        }),
         identifier: id.name,
         name,
       });

--- a/compiler/src/values/SenseableValue.ts
+++ b/compiler/src/values/SenseableValue.ts
@@ -1,7 +1,7 @@
 import { CompilerError } from "../CompilerError";
 import { InstructionBase } from "../instructions";
 import { EMutability, IScope, IValue, TValueInstructions } from "../types";
-import { camelToDashCase, itemNames } from "../utils";
+import { assign, camelToDashCase, itemNames } from "../utils";
 import { LiteralValue } from "./LiteralValue";
 import { StoreValue } from "./StoreValue";
 
@@ -48,7 +48,9 @@ export class SenseableValue extends StoreValue {
       ];
     }
     if (prop instanceof StoreValue) {
-      const temp = new StoreValue(scope);
+      const temp = assign(new SenseableValue(scope), {
+        mutability: EMutability.readonly,
+      });
       return [temp, [new InstructionBase("sensor", temp, this, prop)]];
     }
     throw new CompilerError(`Cannot sense "${prop}" property`);


### PR DESCRIPTION
This pull request makes it possible to:
- pass buildings and units to functions
- receive a senseable value from the `sensor` command
- receive senseable values from dynamic accesses