### PR TITLE
Default parameters for `printFlush` and `drawFlush`

### DIFF
--- a/compiler/lib/commands.d.ts
+++ b/compiler/lib/commands.d.ts
@@ -155,16 +155,20 @@ declare global {
   /**
    * Writes the contents of the print buffer into the target message
    * and clears the buffer afterwards.
-   * @param target
+   * @param target The message building to write to. Writes to `message1` by default.
+   *
+   * Note that the default value only applies if you don't pass any parameter to this function.
    */
-  function printFlush(target: BasicBuilding): void;
+  function printFlush(target?: BasicBuilding): void;
 
   /**
    * Writes the contents of the draw buffer into the target display
    * and clears the buffer afterwards.
-   * @param target
+   * @param target The display building to write to. Writes to `display1` by default.
+   *
+   * Note that the default value only applies if you don't pass any parameter to this function.
    */
-  function drawFlush(target: BasicBuilding): void;
+  function drawFlush(target?: BasicBuilding): void;
 
   /**
    * Gets a block link by its index.

--- a/compiler/src/macros/commands/DrawFlush.ts
+++ b/compiler/src/macros/commands/DrawFlush.ts
@@ -4,9 +4,14 @@ import { IScope, IValue } from "../../types";
 import { SenseableValue } from "../../values";
 import { CompilerError } from "../../CompilerError";
 
+const defaultTargetName = "display1";
+
 export class DrawFlush extends MacroFunction<null> {
   constructor(scope: IScope) {
-    super(scope, (target: IValue) => {
+    super(scope, (target?: IValue) => {
+      if (!target)
+        return [null, [new InstructionBase("drawflush", defaultTargetName)]];
+
       if (!(target instanceof SenseableValue))
         throw new CompilerError(
           "The drawflush target must be a senseable value"

--- a/compiler/src/macros/commands/PrintFlush.ts
+++ b/compiler/src/macros/commands/PrintFlush.ts
@@ -4,9 +4,13 @@ import { IScope, IValue } from "../../types";
 import { SenseableValue } from "../../values";
 import { CompilerError } from "../../CompilerError";
 
+const defaultTargetName = "message1";
 export class PrintFlush extends MacroFunction<null> {
   constructor(scope: IScope) {
-    super(scope, (target: IValue) => {
+    super(scope, (target?: IValue) => {
+      if (!target)
+        return [null, [new InstructionBase("printflush", defaultTargetName)]];
+
       if (!(target instanceof SenseableValue))
         throw new CompilerError(
           "The printflush target must be a senseable value"

--- a/compiler/test/in/block_commands.js
+++ b/compiler/test/in/block_commands.js
@@ -1,12 +1,18 @@
 const conveyor = getBuilding("conveyor1");
-const message = getBuilding("message1");
-const display = getBuilding("display1");
+const message = getBuilding("message3");
+const display = getBuilding("display3");
 const sorter = getBuilding("sorter1");
 const illuminator = getBuilding("illuminator1");
 const cyclone = getBuilding("cyclone1");
 
+// specific ones
 drawFlush(display);
 printFlush(message);
+
+// default ones
+printFlush();
+drawFlush();
+
 const block = getLink(1);
 
 control("color", illuminator, 10, 50, 9);

--- a/compiler/test/out/block_commands.mlog
+++ b/compiler/test/out/block_commands.mlog
@@ -1,8 +1,10 @@
-drawflush display1
+drawflush display3
+printflush message3
 printflush message1
-getlink block:10:6 1
+drawflush display1
+getlink block:16:6 1
 control color illuminator1 10 50 9
-control enabled block:10:6 0
+control enabled block:16:6 0
 control config sorter1 @plastanium
 control shoot cyclone1 20 40 1
 control shootp cyclone1 @unit 1


### PR DESCRIPTION
Makes `printFlush` have `message1` as the default parameter and `drawFlush` have `display1` as the default parameter.

Closes #64 