### PR TITLE
Better usage of template strings

### DIFF
--- a/compiler/doc/commands.md
+++ b/compiler/doc/commands.md
@@ -19,3 +19,4 @@ Here is a list of them, some have multiple overloads
 - `unitRadar` - Uses the unit bound to the processor to find nearby units
 - `unitLocate` - Uses the unit bound to the processor to find blocks
 - `endScript` - Ends the execution of the script (compiles into an `end` instruction)
+- `asm` - Inlines mlog code (can be used with variables and expressions)

--- a/compiler/doc/syntax-support.md
+++ b/compiler/doc/syntax-support.md
@@ -103,6 +103,20 @@ const other = function () {};
 Behavior:
 
 - Functions will be automatically inlined when the size of the body is smaller than the size of the call
+- Some built-in functions such as [asm](/commands) or [print](/commands) can be called with tagged template strings.
+
+```js
+let a = 1;
+let b = 2;
+let c = 3;
+
+print("regular style with ", a, " and ", b, " and ", c);
+print`new style with ${a} and ${b} and ${c}`;
+asm`this is inlined into the final code`;
+```
+
+> This is only possible because the arguments are known at compile time,
+> making it possible for the compiler to know how to deal with each case.
 
 Limitations:
 
@@ -114,6 +128,9 @@ Limitations:
 - No proper support for closures
 - No support for generators
 - No support for `async`/`await`
+- No support for spread syntax
+- No support for destructuring syntax
+- No support for declaring functions that take tagged template strings.
 
 ### For loops
 
@@ -329,38 +346,6 @@ const { firstItem = Items.copper } = building;
 > doesn't know whether the object has such property, and cheking for `null`
 > is not a viable option because returning `null` does not necessarily mean
 > that the property doesn't exist.
-
-### Template strings
-
-Template strings in javascript allow you to interpolate values with strings in
-a convenient way.
-
-But since the mlog runtime doesn't support string contenation template strings are used to
-inline mlog code.
-
-You can see a demonstration bellow.
-
-```js
-const conveyor = getBuilding("conveyor1");
-const message = getBuilding("message1");
-
-print(conveyor.x, conveyor.y);
-
-`printflush ${message}`;
-```
-
-```
-sensor &t0 conveyor1 @x
-sensor &t1 conveyor1 @y
-print &t0
-print &t1
-printflush message1
-end
-```
-
-Behavior:
-
-- Variables inlined on the template string will have their mlog representation on the final code. Works with expressions too.
 
 ## Typescript
 

--- a/compiler/lib/commands.d.ts
+++ b/compiler/lib/commands.d.ts
@@ -541,4 +541,18 @@ declare global {
 
   /** Ends the execution of this script */
   function endScript(): never;
+
+  /**
+   * Inlines raw mlog code. Variables and expressions can be placed inside.
+   *
+   * Although possible, using this function is heavily not recommended since
+   * you lose the benefits of getting type cheking and validation for some
+   * commands.
+   *
+   * ```js
+   *  let x = 10
+   *  asm`ucontrol build ${x} ${x * 2} @router 0 0`
+   * ```
+   */
+  function asm(strings: TemplateStringsArray, ...values: unknown[]): void;
 }

--- a/compiler/lib/commands.d.ts
+++ b/compiler/lib/commands.d.ts
@@ -8,6 +8,14 @@ declare global {
    * To print the contents of the print buffer and empty it call `printFlush`.
    *
    * @param items The items to be added to the print buffer.
+   *
+   * ```js
+   *  // call normally
+   *  print("a + b = ", left, " + ", right, " = ", left + right)
+   *
+   *  // call with tagged string templates
+   *  print`a + b = ${left} + ${right} = ${left + right}`
+   * ```
    */
   function print(...items: unknown[]): void;
 

--- a/compiler/src/handlers/TemplateExpression.ts
+++ b/compiler/src/handlers/TemplateExpression.ts
@@ -1,19 +1,8 @@
-import { ZeroSpaceInstruction } from "../instructions";
-import { es, IInstruction, IValue, THandler } from "../types";
+import { CompilerError } from "../CompilerError";
+import { THandler } from "../types";
 
-export const TemplateLiteral: THandler<null> = (
-  c,
-  scope,
-  node: es.TemplateLiteral
-) => {
-  const args: (string | IValue)[] = [];
-  const inst: IInstruction[] = [];
-  node.expressions.forEach((expression, i) => {
-    const [v, vi] = c.handleConsume(scope, expression);
-    inst.push(...vi);
-    args.push(node.quasis[i].value.raw, v);
-  });
-  args.push(node.quasis.slice(-1)[0].value.raw);
-  inst.push(new ZeroSpaceInstruction(...args));
-  return [null, inst];
+export const TemplateLiteral: THandler<null> = () => {
+  throw new CompilerError(
+    "Template strings are currently unavailable. To inline mlog code use the asm function."
+  );
 };

--- a/compiler/src/initScope.ts
+++ b/compiler/src/initScope.ts
@@ -10,6 +10,7 @@ import { UCommandsNamespace } from "./macros/Namespace";
 import { GetGlobal } from "./macros/GetGlobal";
 import { Scope } from "./Scope";
 import { EMutability } from "./types";
+import { Asm } from "./macros/Asm";
 
 /**
  * Adds all the compiler globals to `scope`
@@ -29,6 +30,7 @@ export function initScope(scope: Scope) {
   scope.hardSet("getBuilding", new GetGlobal(scope, EMutability.constant));
   scope.hardSet("getVar", new GetGlobal(scope, EMutability.mutable));
   scope.hardSet("concat", new Concat(scope));
+  scope.hardSet("asm", new Asm(scope));
 
   scope.hardSet("Math", new MlogMath(scope));
   scope.hardSet("Memory", new MemoryBuilder(scope));

--- a/compiler/src/macros/Asm.ts
+++ b/compiler/src/macros/Asm.ts
@@ -1,0 +1,36 @@
+import { CompilerError } from "../CompilerError";
+import { ZeroSpaceInstruction } from "../instructions";
+import { IScope, IValue } from "../types";
+import { isTemplateObjectArray } from "../utils";
+import { LiteralValue } from "../values";
+import { MacroFunction } from "./Function";
+
+export class Asm extends MacroFunction<null> {
+  constructor(scope: IScope) {
+    super(scope, (stringsArray, ...values) => {
+      if (!isTemplateObjectArray(stringsArray))
+        throw new CompilerError("Expected to receive a template strings array");
+
+      const args: (string | IValue)[] = [];
+
+      for (let i = 0; i < values.length; i++) {
+        const [item] = stringsArray.get(scope, new LiteralValue(scope, i)) as [
+          LiteralValue,
+          never
+        ];
+
+        args.push(item.data as string);
+        args.push(values[i]);
+      }
+
+      const { length } = stringsArray.data;
+
+      const [tail] = stringsArray.get(
+        scope,
+        new LiteralValue(scope, length.data - 1)
+      ) as [LiteralValue, never];
+      args.push(tail.data as string);
+      return [null, [new ZeroSpaceInstruction(...args)]];
+    });
+  }
+}

--- a/compiler/src/macros/commands/Print.ts
+++ b/compiler/src/macros/commands/Print.ts
@@ -1,16 +1,36 @@
 import { InstructionBase } from "../../instructions";
 import { MacroFunction } from "..";
 import { IInstruction, IScope, IValue } from "../../types";
+import { LiteralValue } from "../../values";
+import { isTemplateObjectArray } from "../../utils";
 
 export class Print extends MacroFunction<null> {
   constructor(scope: IScope) {
     super(scope, (...values: IValue[]) => {
+      const [first] = values;
       const inst: IInstruction[] = [];
 
-      for (const value of values) {
-        inst.push(new InstructionBase("print", value));
+      if (!isTemplateObjectArray(first)) {
+        for (const value of values) {
+          inst.push(new InstructionBase("print", value));
+        }
+
+        return [null, inst];
       }
 
+      // `first` is likely a template strings array
+      // maybe this should be checked in another way?
+      const { length } = first.data;
+
+      for (let i = 1; i < values.length; i++) {
+        const [string] = first.get(scope, new LiteralValue(scope, i - 1));
+        inst.push(new InstructionBase("print", string));
+        inst.push(new InstructionBase("print", values[i]));
+      }
+
+      const [tail] = first.get(scope, new LiteralValue(scope, length.data - 1));
+
+      inst.push(new InstructionBase("print", tail));
       return [null, inst];
     });
   }

--- a/compiler/src/utils.ts
+++ b/compiler/src/utils.ts
@@ -1,4 +1,5 @@
 import { es, IValue, TValueInstructions } from "./types";
+import { IObjectValueData, LiteralValue, ObjectValue } from "./values";
 
 /**
  * The prefix for internal variables inside the compiler output
@@ -81,4 +82,28 @@ export function withAlwaysRuns<T extends IValue | null>(
 ) {
   valueInst[1].forEach(inst => (inst.alwaysRuns = value));
   return valueInst;
+}
+
+export function isTemplateObjectArray(value: IValue): value is ObjectValue & {
+  data: IObjectValueData & {
+    raw: ObjectValue & {
+      data: IObjectValueData & {
+        length: LiteralValue & {
+          data: number;
+        };
+      };
+    };
+    length: LiteralValue & {
+      data: number;
+    };
+  };
+} {
+  return (
+    value instanceof ObjectValue &&
+    value.data.length instanceof LiteralValue &&
+    typeof value.data.length.data === "number" &&
+    value.data.raw instanceof ObjectValue &&
+    value.data.raw.data.length instanceof LiteralValue &&
+    typeof value.data.raw.data.length.data === "number"
+  );
 }

--- a/compiler/src/values/ObjectValue.ts
+++ b/compiler/src/values/ObjectValue.ts
@@ -31,9 +31,11 @@ export class ObjectValue extends VoidValue {
 
   static fromArray(
     scope: IScope,
-    items: IObjectValueData[keyof IObjectValueData][]
+    items: IObjectValueData[keyof IObjectValueData][],
+    intialData?: IObjectValueData
   ): ObjectValue {
     const data: IObjectValueData = {
+      ...intialData,
       length: new LiteralValue(scope, items.length),
     };
     items.forEach((item, i) => {

--- a/compiler/test/in/print.js
+++ b/compiler/test/in/print.js
@@ -3,3 +3,8 @@ print("first", "second", "third");
 
 const variable = getVar("@foo");
 print(variable);
+
+print`variable ${variable}
+using
+tagged
+templates`;

--- a/compiler/test/in/template_strings.js
+++ b/compiler/test/in/template_strings.js
@@ -4,9 +4,10 @@ let first = 10;
 let second = 0.2;
 
 // raw use of radar
-`radar player enemy any distance ${turret} 1 radarResult`;
+asm`radar player enemy any distance ${turret} 1 radarResult`;
 
 // temporary values should work too
-`op mul foo ${first + second} 2`;
+asm`op mul foo ${first + second} 2`;
+
 print(getVar("radarResult"));
 print(getVar("foo"));

--- a/compiler/test/out/print.mlog
+++ b/compiler/test/out/print.mlog
@@ -4,4 +4,7 @@ print "second"
 print "third"
 set variable:4:6 @foo
 print variable:4:6
+print "variable "
+print variable:4:6
+print "\nusing\ntagged\ntemplates"
 end


### PR DESCRIPTION
With this pull request, template strings cannot be used only by themselves, but they can be used inside a tagged template expression, allowing it to have more uses and be more flexible.

Changes:
- Now using standalone template strings throws an error.
- The `print` command can now be used with tagged templates.
- The `asm` command now serves the function of standalone template strings.