### PR TITLE
Support multiline `asm` calls

### DIFF
--- a/compiler/src/macros/Asm.ts
+++ b/compiler/src/macros/Asm.ts
@@ -1,6 +1,6 @@
 import { CompilerError } from "../CompilerError";
 import { ZeroSpaceInstruction } from "../instructions";
-import { IScope, IValue } from "../types";
+import { IInstruction, IScope, IValue } from "../types";
 import { isTemplateObjectArray } from "../utils";
 import { LiteralValue } from "../values";
 import { MacroFunction } from "./Function";
@@ -30,7 +30,70 @@ export class Asm extends MacroFunction<null> {
         new LiteralValue(scope, length.data - 1)
       ) as [LiteralValue, never];
       args.push(tail.data as string);
-      return [null, [new ZeroSpaceInstruction(...args)]];
+
+      return [null, formatInstructions(args)];
     });
   }
+}
+
+/** Splits multiline asm calls and formats each line. */
+function formatInstructions(args: (string | IValue)[]) {
+  const instructions: IInstruction[] = [];
+  let last = 0;
+
+  let previous: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (typeof arg !== "string" || !arg.includes("\n")) {
+      continue;
+    }
+
+    const segments = arg.split("\n");
+
+    const params = [...previous, ...args.slice(last, i), segments[0]];
+
+    if (validateInstructionArgs(params)) {
+      instructions.push(new ZeroSpaceInstruction(...params));
+      previous = [];
+    }
+
+    for (let i = 1; i < segments.length - 1; i++) {
+      const trimmed = segments[i].trim();
+      if (trimmed.length == 0) continue;
+      instructions.push(new ZeroSpaceInstruction(trimmed));
+    }
+
+    if (segments.length > 1) {
+      previous.push(segments[segments.length - 1]);
+    }
+
+    last = i + 1;
+  }
+
+  if (last < args.length) {
+    const params = args.slice(last);
+    validateInstructionArgs(params);
+    instructions.push(new ZeroSpaceInstruction(...params));
+  }
+
+  return instructions;
+}
+
+/** Determines if an asm line should be generated and trims it at the start and end */
+function validateInstructionArgs(args: (string | IValue)[]) {
+  if (args.length === 0) return false;
+  if (args.length === 1) {
+    const item = args[0];
+    if (typeof item !== "string") return true;
+    args[0] = item.trim();
+    return args[0].length !== 0;
+  }
+
+  const first = args[0];
+  const last = args[args.length - 1];
+  if (typeof first === "string") args[0] = first.trimStart();
+  if (typeof last === "string") args[args.length - 1] = last.trimEnd();
+  return true;
 }

--- a/compiler/test/in/template_strings.js
+++ b/compiler/test/in/template_strings.js
@@ -9,5 +9,12 @@ asm`radar player enemy any distance ${turret} 1 radarResult`;
 // temporary values should work too
 asm`op mul foo ${first + second} 2`;
 
+asm`
+multine should be properly
+        formatted
+        ${first}    
+    d ${second} a
+`;
+
 print(getVar("radarResult"));
 print(getVar("foo"));

--- a/compiler/test/out/template_strings.mlog
+++ b/compiler/test/out/template_strings.mlog
@@ -3,6 +3,10 @@ set second:4:4 0.2
 radar player enemy any distance cyclone1 1 radarResult
 op add &t0 first:3:4 second:4:4
 op mul foo &t0 2
+multine should be properly
+formatted
+first:3:4
+d second:4:4 a
 print radarResult
 print foo
 end


### PR DESCRIPTION
Prevents `asm` calls that contain line ends (`\n`) to break the sourcemapping and also trims them their content.

```js
asm`
this should now work 

   and should be properly formatted
`
```