### PR TITLE
Fix `asm` function string formatter

### DIFF
--- a/compiler/test/in/template_strings.js
+++ b/compiler/test/in/template_strings.js
@@ -14,7 +14,8 @@ multine should be properly
         formatted
         ${first}    
     d ${second} a
-`;
+
+    \nstuff`;
 
 print(getVar("radarResult"));
 print(getVar("foo"));

--- a/compiler/test/out/template_strings.mlog
+++ b/compiler/test/out/template_strings.mlog
@@ -7,6 +7,7 @@ multine should be properly
 formatted
 first:3:4
 d second:4:4 a
+stuff
 print radarResult
 print foo
 end


### PR DESCRIPTION
Fixes #100. The `asm` function will now correctly format the input string.