### PR TITLE
Fix null coalescing operator

### DIFF
--- a/compiler/src/instructions/SetInstruction.ts
+++ b/compiler/src/instructions/SetInstruction.ts
@@ -1,12 +1,31 @@
 import { InstructionBase } from ".";
 import { IValue } from "../types";
+import { StoreValue } from "../values";
 
 export class SetInstruction extends InstructionBase {
   constructor(store: IValue, value: IValue) {
     super("set", store, value);
   }
 
+  get store() {
+    return this.args[1] as IValue;
+  }
+
+  get value() {
+    return this.args[2] as IValue;
+  }
+
   get hidden(): boolean {
-    return this._hidden || !(this.args[1] as IValue).owner;
+    const { store, value } = this;
+    return (
+      this._hidden ||
+      // assignment to discarded value
+      !store.owner ||
+      // self assignment of a store
+      (!!store.owner &&
+        store instanceof StoreValue &&
+        value instanceof StoreValue &&
+        store.owner === value.owner)
+    );
   }
 }

--- a/compiler/src/operators.ts
+++ b/compiler/src/operators.ts
@@ -45,7 +45,7 @@ export const arithmeticAssignmentOperators = [
   "-=",
   "/=",
 ] as const;
-export const logicalAssignmentOperators = ["&&=", "||="] as const;
+export const logicalAssignmentOperators = ["&&=", "||=", "??="] as const;
 export const bitwiseAssignmentOperators = [
   "<<=",
   ">>=",

--- a/compiler/src/types.ts
+++ b/compiler/src/types.ts
@@ -195,6 +195,7 @@ export interface IValueOperators {
   "/="(scope: IScope, value: IValue): TValueInstructions;
   "&&="(scope: IScope, value: IValue): TValueInstructions;
   "||="(scope: IScope, value: IValue): TValueInstructions;
+  "??="(scope: IScope, value: IValue): TValueInstructions;
   "<<="(scope: IScope, value: IValue): TValueInstructions;
   ">>="(scope: IScope, value: IValue): TValueInstructions;
   ">>>="(scope: IScope, value: IValue): TValueInstructions;

--- a/compiler/test/in/expressions.js
+++ b/compiler/test/in/expressions.js
@@ -18,3 +18,7 @@ print(
   offset ?? "offset is null?",
   "preserved" ?? "should not appear"
 );
+
+let item = Math.rand(1) > 0.5 ? null : Items.beryllium;
+
+item ??= Items.copper;

--- a/compiler/test/out/expressions.mlog
+++ b/compiler/test/out/expressions.mlog
@@ -25,4 +25,12 @@ set &t7 "offset is null?"
 print "null is null"
 print &t7
 print "preserved"
+op rand &t8 1
+op greaterThan &t9 &t8 0.5
+jump 32 equal &t9 0
+set item:22:4 null
+jump 33 always
+set item:22:4 @beryllium
+jump 35 notEqual item:22:4 null
+set item:22:4 @copper
 end


### PR DESCRIPTION
Updates the special implementation for the null coalescing operator to work in an assignment expression (`??=`).

This pull request also makes `set` instructions hide if they contain a self-assignment