### PR TITLE
Patch `control.color`

### DIFF
--- a/compiler/test/out/block_commands.mlog
+++ b/compiler/test/out/block_commands.mlog
@@ -3,7 +3,8 @@ printflush message3
 printflush message1
 drawflush display1
 getlink block:16:6 1
-control color illuminator1 10 50 9
+packcolor &t0 10 50 9
+control color illuminator1 &t0
 control enabled block:16:6 0
 control config sorter1 @plastanium
 control shoot cyclone1 20 40 1


### PR DESCRIPTION
At some point (probably after the `packcolor` instruction was introduced) the `control color` instruction stopped
taking the RGB colors to instead take the RGB data produced by `packcolor`.

This pull request is a patch to adapt to that new behavior without breaking existing code.