### PR TITLE
Fix function returns

### DIFF
--- a/compiler/src/values/FunctionValue.ts
+++ b/compiler/src/values/FunctionValue.ts
@@ -244,6 +244,14 @@ export class FunctionValue extends VoidValue implements IFunctionValue {
 function endsWithReturn(inst: IInstruction[]) {
   for (let i = inst.length - 1; i >= 0; i--) {
     const instruction = inst[i];
+
+    // this means that there is an instruction trying to reference
+    // the final function `set @counter` instruction
+    // of course this generates an unecessary
+    // `set @counter` in cases where a control flow
+    // structure contains a fallback return statement
+    // TODO: fix this with static analysis
+    if (instruction instanceof AddressResolver) return false;
     if (instruction.hidden) continue;
     return instruction instanceof SetCounterInstruction;
   }

--- a/compiler/test/out/functions.mlog
+++ b/compiler/test/out/functions.mlog
@@ -28,3 +28,4 @@ op strictEqual &t3:op:26:0 type:26:12 3
 jump 30 equal &t3:op:26:0 0
 op div &fop:26:0 a:26:18 b:26:21
 set @counter &rop:26:0
+set @counter &rop:26:0

--- a/compiler/test/out/switch_basic.mlog
+++ b/compiler/test/out/switch_basic.mlog
@@ -7,13 +7,13 @@ set &t1:matchItem:18:0 @sand
 print &t1:matchItem:18:0
 set item:57:18 @copper
 set &ritemUses:57:0 10
-jump 70 always
+jump 71 always
 set item:57:18 @coal
 set &ritemUses:57:0 13
-jump 70 always
+jump 71 always
 set item:57:18 @silicon
 set &ritemUses:57:0 16
-jump 70 always
+jump 71 always
 print "always runs!\n"
 printflush message1
 end
@@ -68,18 +68,19 @@ set &fmatchItem:18:0 @pyratite
 set @counter &rmatchItem:18:0
 set &fmatchItem:18:0 null
 set @counter &rmatchItem:18:0
-jump 74 strictEqual item:57:18 @copper
-jump 78 strictEqual item:57:18 @coal
-jump 82 strictEqual item:57:18 @silicon
-jump 83 always
+set @counter &rmatchItem:18:0
+jump 75 strictEqual item:57:18 @copper
+jump 79 strictEqual item:57:18 @coal
+jump 83 strictEqual item:57:18 @silicon
+jump 84 always
 print "Basic material\n"
 print "Ammo for some units\n"
 print "Duo ammo\n"
-jump 83 always
+jump 84 always
 print "Burn things\n"
 print "Scorch ammo\n"
 print "Energy\n"
-jump 83 always
+jump 84 always
 print "Silligone\n"
 print "Something at the end\n"
 set @counter &ritemUses:57:0


### PR DESCRIPTION
This fixes #113.

This pull requests adds a check for adress resolvers that are supposed to reference the last `set @counter` instruction.