### PR TITLE
Use temp values for function returns

### DIFF
--- a/compiler/src/values/FunctionValue.ts
+++ b/compiler/src/values/FunctionValue.ts
@@ -137,6 +137,8 @@ export class FunctionValue extends VoidValue implements IFunctionValue {
     return [null, [...argInst, returnInst]];
   }
 
+  // TODO: use static analysis to determine if
+  // we can safely skip the temp value assignment
   private normalCall(scope: IScope, args: IValue[]): TValueInstructions {
     if (!this.bundled) this.childScope.inst.push(...this.inst);
     this.bundled = true;

--- a/compiler/test/examples/fibonacci.mlog
+++ b/compiler/test/examples/fibonacci.mlog
@@ -1,11 +1,12 @@
 set n:4:19 10
 set &rfibonacci:4:0 3
-jump 6 always
-print &ffibonacci:4:0
+jump 7 always
+set &t0 &ffibonacci:4:0
+print &t0
 printflush message1
 end
 op lessThanEq &t0:fibonacci:4:0 n:4:19 2
-jump 10 equal &t0:fibonacci:4:0 0
+jump 11 equal &t0:fibonacci:4:0 0
 set &ffibonacci:4:0 1
 set @counter &rfibonacci:4:0
 set a:7:6 1
@@ -13,11 +14,11 @@ set b:8:6 1
 set c:9:6 2
 set i:11:11 3
 op lessThanEq &t1:fibonacci:4:0 i:11:11 n:4:19
-jump 21 equal &t1:fibonacci:4:0 0
+jump 22 equal &t1:fibonacci:4:0 0
 op add c:9:6 a:7:6 b:8:6
 set a:7:6 b:8:6
 set b:8:6 c:9:6
 op add i:11:11 i:11:11 1
-jump 14 always
+jump 15 always
 set &ffibonacci:4:0 c:9:6
 set @counter &rfibonacci:4:0

--- a/compiler/test/out/switch_basic.mlog
+++ b/compiler/test/out/switch_basic.mlog
@@ -1,39 +1,40 @@
 set dynamicItem:1:4 4
 set n:18:19 dynamicItem:1:4
 set &rmatchItem:18:0 4
-jump 19 always
-print &fmatchItem:18:0
+jump 20 always
+set &t0 &fmatchItem:18:0
+print &t0
 set &t1:matchItem:18:0 @sand
 print &t1:matchItem:18:0
 set item:57:18 @copper
-set &ritemUses:57:0 10
-jump 71 always
+set &ritemUses:57:0 11
+jump 72 always
 set item:57:18 @coal
-set &ritemUses:57:0 13
-jump 71 always
+set &ritemUses:57:0 14
+jump 72 always
 set item:57:18 @silicon
-set &ritemUses:57:0 16
-jump 71 always
+set &ritemUses:57:0 17
+jump 72 always
 print "always runs!\n"
 printflush message1
 end
-jump 36 strictEqual n:18:19 1
-jump 38 strictEqual n:18:19 2
-jump 40 strictEqual n:18:19 3
-jump 42 strictEqual n:18:19 4
-jump 44 strictEqual n:18:19 5
-jump 46 strictEqual n:18:19 6
-jump 48 strictEqual n:18:19 7
-jump 50 strictEqual n:18:19 8
-jump 52 strictEqual n:18:19 9
-jump 54 strictEqual n:18:19 10
-jump 56 strictEqual n:18:19 11
-jump 58 strictEqual n:18:19 12
-jump 60 strictEqual n:18:19 13
-jump 62 strictEqual n:18:19 14
-jump 64 strictEqual n:18:19 15
-jump 66 strictEqual n:18:19 16
-jump 68 always
+jump 37 strictEqual n:18:19 1
+jump 39 strictEqual n:18:19 2
+jump 41 strictEqual n:18:19 3
+jump 43 strictEqual n:18:19 4
+jump 45 strictEqual n:18:19 5
+jump 47 strictEqual n:18:19 6
+jump 49 strictEqual n:18:19 7
+jump 51 strictEqual n:18:19 8
+jump 53 strictEqual n:18:19 9
+jump 55 strictEqual n:18:19 10
+jump 57 strictEqual n:18:19 11
+jump 59 strictEqual n:18:19 12
+jump 61 strictEqual n:18:19 13
+jump 63 strictEqual n:18:19 14
+jump 65 strictEqual n:18:19 15
+jump 67 strictEqual n:18:19 16
+jump 69 always
 set &fmatchItem:18:0 @copper
 set @counter &rmatchItem:18:0
 set &fmatchItem:18:0 @lead
@@ -69,18 +70,18 @@ set @counter &rmatchItem:18:0
 set &fmatchItem:18:0 null
 set @counter &rmatchItem:18:0
 set @counter &rmatchItem:18:0
-jump 75 strictEqual item:57:18 @copper
-jump 79 strictEqual item:57:18 @coal
-jump 83 strictEqual item:57:18 @silicon
-jump 84 always
+jump 76 strictEqual item:57:18 @copper
+jump 80 strictEqual item:57:18 @coal
+jump 84 strictEqual item:57:18 @silicon
+jump 85 always
 print "Basic material\n"
 print "Ammo for some units\n"
 print "Duo ammo\n"
-jump 84 always
+jump 85 always
 print "Burn things\n"
 print "Scorch ammo\n"
 print "Energy\n"
-jump 84 always
+jump 85 always
 print "Silligone\n"
 print "Something at the end\n"
 set @counter &ritemUses:57:0


### PR DESCRIPTION
This prevents the function return value to be overridden if the function is called multiple times inside an expression.

Fixes #115.