### PR TITLE
Upgrade literals

### DIFF
--- a/compiler/src/assertions.ts
+++ b/compiler/src/assertions.ts
@@ -6,8 +6,8 @@ import { LiteralValue, ObjectValue, StoreValue } from "./values";
 export function assertStringLiteral(
   value: IValue | undefined,
   name: string
-): asserts value is LiteralValue & { data: string } {
-  if (!(value instanceof LiteralValue) || typeof value.data !== "string")
+): asserts value is LiteralValue<string> {
+  if (!(value instanceof LiteralValue) || !value.isString())
     throw new CompilerError(`${name} must be a string literal`);
 }
 
@@ -16,7 +16,7 @@ export function assertLiteralOneOf<T extends readonly string[]>(
   value: IValue | undefined,
   members: T,
   name: string
-): asserts value is LiteralValue & { data: T[number] } {
+): asserts value is LiteralValue<T[number]> {
   assertStringLiteral(value, name);
   if (!members.includes(value.data))
     throw new CompilerError(

--- a/compiler/src/handlers/ForStatement.ts
+++ b/compiler/src/handlers/ForStatement.ts
@@ -15,10 +15,10 @@ export const ForStatement: THandler<null> = (
     ? c.handleConsume(scope, node.test)
     : [new LiteralValue(1), []];
   const updateLines = node.update ? c.handle(scope, node.update)[1] : [];
-  const startLoopAddr = new LiteralValue(null as never);
+  const startLoopAddr = new LiteralValue(null);
   // continue statements jump here to run the loop update lines
-  const beforeEndAddr = new LiteralValue(null as never);
-  const endLoopAddr = new LiteralValue(null as never);
+  const beforeEndAddr = new LiteralValue(null);
+  const endLoopAddr = new LiteralValue(null);
 
   const startLoopLine = new AddressResolver(startLoopAddr);
   const endLoopLine = new AddressResolver(endLoopAddr).bindBreak(scope);

--- a/compiler/src/handlers/IfStatement.ts
+++ b/compiler/src/handlers/IfStatement.ts
@@ -14,7 +14,7 @@ export const IfStatement: THandler<null> = (c, scope, node: es.IfStatement) => {
     return [null, inst];
   }
 
-  const endIfAddr = new LiteralValue(null as never);
+  const endIfAddr = new LiteralValue(null);
 
   inst.push(
     ...testInst,
@@ -23,7 +23,7 @@ export const IfStatement: THandler<null> = (c, scope, node: es.IfStatement) => {
     new AddressResolver(endIfAddr)
   );
 
-  const endElseAddr = new LiteralValue(null as never);
+  const endElseAddr = new LiteralValue(null);
   if (node.alternate) {
     inst.push(
       new JumpInstruction(endElseAddr, EJumpKind.Always),

--- a/compiler/src/handlers/Literal.ts
+++ b/compiler/src/handlers/Literal.ts
@@ -1,19 +1,16 @@
-import { THandler, es, TLiteral } from "../types";
+import { THandler, es } from "../types";
 import { LiteralValue } from "../values";
 
 const Literal: THandler = (
   _c,
   scope,
   node: es.StringLiteral | es.NumericLiteral
-) => [new LiteralValue(node.value as TLiteral), []];
+) => [new LiteralValue(node.value), []];
 
 export const NumericLiteral = Literal;
 export const StringLiteral = Literal;
 
-export const NullLiteral: THandler = () => [
-  new LiteralValue(null as unknown as TLiteral),
-  [],
-];
+export const NullLiteral: THandler = () => [new LiteralValue(null), []];
 
 export const BooleanLiteral: THandler = (
   _c,

--- a/compiler/src/handlers/OperationExpressions.ts
+++ b/compiler/src/handlers/OperationExpressions.ts
@@ -106,8 +106,8 @@ export const ConditionalExpression: THandler = (
   result.ensureOwned();
   const consequent = c.handleEval(scope, node.consequent);
   const alternate = c.handleEval(scope, node.alternate);
-  const alternateStartAdress = new LiteralValue(null as never);
-  const endExpressionAdress = new LiteralValue(null as never);
+  const alternateStartAdress = new LiteralValue(null);
+  const endExpressionAdress = new LiteralValue(null);
 
   return [
     result,

--- a/compiler/src/handlers/Statements.ts
+++ b/compiler/src/handlers/Statements.ts
@@ -23,7 +23,7 @@ export const BreakStatement: THandler<null> = (
   const label = node.label?.name;
 
   const target = label ? findScopeLabel(scope, label) : scope;
-  const addr = new LiteralValue(null as never);
+  const addr = new LiteralValue(null);
   target.break.bind(addr);
 
   return [null, [new BreakInstruction(addr)]];
@@ -34,7 +34,7 @@ export const ContinueStatement: THandler<null> = (
   scope,
   node: es.ContinueStatement
 ) => {
-  const addr = new LiteralValue(null as never);
+  const addr = new LiteralValue(null);
 
   const label = node.label?.name;
 
@@ -64,7 +64,7 @@ export const LabeledStatement: THandler<null> = (
   const inner = scope.createScope();
   inner.label = node.label.name;
 
-  const end = new LiteralValue(null as never);
+  const end = new LiteralValue(null);
   const endAdress = new AddressResolver(end).bindBreak(inner);
 
   const [, bodyInst] = c.handle(inner, node.body);

--- a/compiler/src/handlers/SwitchStatement.ts
+++ b/compiler/src/handlers/SwitchStatement.ts
@@ -14,7 +14,7 @@ export const SwitchStatement: THandler<null> = (
 
   const inst: IInstruction[] = [];
 
-  const endAdress = new LiteralValue(null as never);
+  const endAdress = new LiteralValue(null);
   const endLine = new AddressResolver(endAdress).bindBreak(innerScope);
 
   const caseJumps: IInstruction[] = [];
@@ -22,7 +22,7 @@ export const SwitchStatement: THandler<null> = (
 
   for (const scase of node.cases) {
     const [, bodyInst] = c.handleMany(innerScope, scase.consequent);
-    const bodyAdress = new LiteralValue(null as never);
+    const bodyAdress = new LiteralValue(null);
     const bodyLine = new AddressResolver(bodyAdress);
 
     if (!scase.test) {

--- a/compiler/src/handlers/Typescript.ts
+++ b/compiler/src/handlers/Typescript.ts
@@ -50,7 +50,7 @@ export const TSEnumDeclaration: THandler<null> = (
         member
       );
 
-    if (typeof value.data === "number") {
+    if (value.isNumber()) {
       lastType = "number";
       counter = value.data + 1;
     } else {

--- a/compiler/src/handlers/WhileStatement.ts
+++ b/compiler/src/handlers/WhileStatement.ts
@@ -12,8 +12,8 @@ export const WhileStatement: THandler<null> = (
   const [test, testLines] = c.handleConsume(scope, node.test);
 
   const childScope = scope.createScope();
-  const startLoopAddr = new LiteralValue(null as never);
-  const endLoopAddr = new LiteralValue(null as never);
+  const startLoopAddr = new LiteralValue(null);
+  const endLoopAddr = new LiteralValue(null);
   const startLoopLine = new AddressResolver(startLoopAddr).bindContinue(
     childScope
   );
@@ -60,7 +60,7 @@ export const DoWhileStatement: THandler<null> = (
   const [test, testLines] = c.handleConsume(scope, node.test);
 
   const childScope = scope.createScope();
-  const startLoopAddr = new LiteralValue(null as never);
+  const startLoopAddr = new LiteralValue(null);
   const startLoopLine = new AddressResolver(startLoopAddr).bindContinue(
     childScope
   );

--- a/compiler/src/instructions/AddressResolver.ts
+++ b/compiler/src/instructions/AddressResolver.ts
@@ -6,15 +6,15 @@ export class AddressResolver extends InstructionBase {
     return true;
   }
   public set hidden(value) {}
-  bonds: IBindableValue[];
-  constructor(...bonds: IBindableValue[]) {
+  bonds: IBindableValue<number | null>[];
+  constructor(...bonds: IBindableValue<number | null>[]) {
     super();
     this.bonds = bonds;
   }
   resolve(i: number) {
     for (const literal of this.bonds) literal.data = i;
   }
-  bind(bond: IBindableValue) {
+  bind(bond: IBindableValue<number | null>) {
     this.bonds.push(bond);
   }
   bindBreak(scope: IScope) {

--- a/compiler/src/instructions/ControlInstructions.ts
+++ b/compiler/src/instructions/ControlInstructions.ts
@@ -4,7 +4,7 @@ import { EJumpKind, JumpInstruction } from "./JumpInstruction";
 export class BreakInstruction extends JumpInstruction {
   intent = EInstIntent.break;
 
-  constructor(address: IBindableValue) {
+  constructor(address: IBindableValue<number | null>) {
     super(address, EJumpKind.Always);
   }
 }
@@ -12,7 +12,7 @@ export class BreakInstruction extends JumpInstruction {
 export class ContinueInstruction extends JumpInstruction {
   intent = EInstIntent.continue;
 
-  constructor(address: IBindableValue) {
+  constructor(address: IBindableValue<number | null>) {
     super(address, EJumpKind.Always);
   }
 }

--- a/compiler/src/instructions/JumpInstruction.ts
+++ b/compiler/src/instructions/JumpInstruction.ts
@@ -14,7 +14,7 @@ export enum EJumpKind {
 
 export class JumpInstruction extends InstructionBase {
   constructor(
-    public address: IBindableValue,
+    public address: IBindableValue<number | null>,
     kind: EJumpKind,
     left: IValue | null = null,
     right: IValue | null = null

--- a/compiler/src/macros/Asm.ts
+++ b/compiler/src/macros/Asm.ts
@@ -15,11 +15,11 @@ export class Asm extends MacroFunction<null> {
 
       for (let i = 0; i < values.length; i++) {
         const [item] = stringsArray.get(scope, new LiteralValue(i)) as [
-          LiteralValue,
+          LiteralValue<string>,
           never
         ];
 
-        args.push(item.data as string);
+        args.push(item.data);
         args.push(values[i]);
       }
 
@@ -28,8 +28,8 @@ export class Asm extends MacroFunction<null> {
       const [tail] = stringsArray.get(
         scope,
         new LiteralValue(length.data - 1)
-      ) as [LiteralValue, never];
-      args.push(tail.data as string);
+      ) as [LiteralValue<string>, never];
+      args.push(tail.data);
 
       return [null, formatInstructions(args)];
     });

--- a/compiler/src/macros/GetGlobal.ts
+++ b/compiler/src/macros/GetGlobal.ts
@@ -8,7 +8,7 @@ import { MacroFunction } from "./Function";
 export class GetGlobal extends MacroFunction {
   constructor(mutability: EMutability) {
     super((scope, name: IValue) => {
-      if (!(name instanceof LiteralValue) || typeof name.data !== "string")
+      if (!(name instanceof LiteralValue) || !name.isString())
         throw new CompilerError("The name parameter must be a string literal.");
 
       const owner = new ValueOwner({

--- a/compiler/src/macros/Math.ts
+++ b/compiler/src/macros/Math.ts
@@ -59,7 +59,7 @@ function createMacroMathOperations(scope: IScope) {
     macroMathOperations[key] = new MacroFunction<IValue>((scope, a, b) => {
       if (b) {
         if (fn && a instanceof LiteralValue && b instanceof LiteralValue) {
-          if (typeof a.data !== "number" || typeof b.data !== "number")
+          if (!a.isNumber() || !b.isNumber())
             throw new CompilerError(
               "Cannot do math operation with non-numerical literals."
             );
@@ -69,7 +69,7 @@ function createMacroMathOperations(scope: IScope) {
         return [temp, [new OperationInstruction(key, temp, a, b)]];
       }
       if (fn && a instanceof LiteralValue) {
-        if (typeof a.data !== "number")
+        if (!a.isNumber())
           throw new CompilerError(
             "Cannot do math operation with non-numerical literal."
           );

--- a/compiler/src/macros/Memory.ts
+++ b/compiler/src/macros/Memory.ts
@@ -75,7 +75,7 @@ class MemoryMacro extends ObjectValue {
   constructor(public cell: SenseableValue, size: LiteralValue) {
     super({
       $get: new MacroFunction((scope, prop: IValue) => {
-        if (prop instanceof LiteralValue && typeof prop.data !== "number")
+        if (prop instanceof LiteralValue && !prop.isNumber())
           throw new CompilerError(
             `Invalid memory object property: "${prop.data}"`
           );
@@ -100,7 +100,7 @@ export class MemoryBuilder extends ObjectValue {
           if (!(cell instanceof SenseableValue))
             throw new CompilerError("Memory cell must be a senseable value.");
 
-          if (!(size instanceof LiteralValue && typeof size.data === "number"))
+          if (!(size instanceof LiteralValue && size.isNumber()))
             throw new CompilerError(
               "The memory size must be a number literal."
             );

--- a/compiler/src/macros/Namespace.ts
+++ b/compiler/src/macros/Namespace.ts
@@ -21,7 +21,7 @@ export class NamespaceMacro extends ObjectValue {
   constructor({ changeCasing = false }: NamespaceMacroOptions = {}) {
     super({
       $get: new MacroFunction((scope, prop) => {
-        if (!(prop instanceof LiteralValue) || typeof prop.data !== "string")
+        if (!(prop instanceof LiteralValue) || !prop.isString())
           throw new CompilerError(
             "Cannot use dynamic properties on namespace macros"
           );

--- a/compiler/src/macros/commands/GetLink.ts
+++ b/compiler/src/macros/commands/GetLink.ts
@@ -9,7 +9,7 @@ export class GetLink extends MacroFunction {
     super((scope, index: IValue) => {
       if (
         !(index instanceof StoreValue) &&
-        (!(index instanceof LiteralValue) || typeof index.data !== "number")
+        (!(index instanceof LiteralValue) || !index.isNumber())
       )
         throw new CompilerError(
           "The getlink index must be a number literal or a store"

--- a/compiler/src/macros/commands/PackColor.ts
+++ b/compiler/src/macros/commands/PackColor.ts
@@ -16,7 +16,7 @@ export class PackColor extends MacroFunction {
         !args.every(
           (value): value is StoreValue | LiteralValue =>
             value instanceof StoreValue ||
-            (value instanceof LiteralValue && typeof value.data === "number")
+            (value instanceof LiteralValue && value.isNumber())
         )
       ) {
         throw new CompilerError(

--- a/compiler/src/macros/commands/Radar.ts
+++ b/compiler/src/macros/commands/Radar.ts
@@ -40,7 +40,7 @@ export class Radar extends MacroFunction {
 
       const { length } = filters.data;
 
-      if (!(length instanceof LiteralValue) || typeof length.data !== "number")
+      if (!(length instanceof LiteralValue) || !length.isNumber())
         throw new CompilerError("The length of an array macro must be");
 
       if (length.data !== 3)

--- a/compiler/src/macros/commands/UnitRadar.ts
+++ b/compiler/src/macros/commands/UnitRadar.ts
@@ -20,7 +20,7 @@ export class UnitRadar extends MacroFunction {
 
       const { length } = filters.data;
 
-      if (!(length instanceof LiteralValue) || typeof length.data !== "number")
+      if (!(length instanceof LiteralValue) || !length.isNumber())
         throw new CompilerError("The length of an array macro must be");
 
       if (length.data !== 3)

--- a/compiler/src/macros/commands/Wait.ts
+++ b/compiler/src/macros/commands/Wait.ts
@@ -8,7 +8,7 @@ export class Wait extends MacroFunction<null> {
     super((scope, seconds) => {
       if (
         !(seconds instanceof StoreValue) &&
-        !(seconds instanceof LiteralValue && typeof seconds.data === "number")
+        !(seconds instanceof LiteralValue && seconds.isNumber())
       )
         throw new CompilerError(
           "The wait seconds must be either a number literal or a store"

--- a/compiler/src/types.ts
+++ b/compiler/src/types.ts
@@ -246,8 +246,9 @@ export interface IOwnedValue extends IValue {
 }
 
 export type TLiteral = string | number;
-export interface IBindableValue extends IValue {
-  data: TLiteral;
+export interface IBindableValue<T extends TLiteral | null = TLiteral>
+  extends IValue {
+  data: T;
 }
 
 export interface IFunctionValue extends IValue {

--- a/compiler/src/utils.ts
+++ b/compiler/src/utils.ts
@@ -95,22 +95,18 @@ export function isTemplateObjectArray(value: IValue): value is ObjectValue & {
   data: IObjectValueData & {
     raw: ObjectValue & {
       data: IObjectValueData & {
-        length: LiteralValue & {
-          data: number;
-        };
+        length: LiteralValue<number>;
       };
     };
-    length: LiteralValue & {
-      data: number;
-    };
+    length: LiteralValue<number>;
   };
 } {
   return (
     value instanceof ObjectValue &&
     value.data.length instanceof LiteralValue &&
-    typeof value.data.length.data === "number" &&
+    value.data.length.isNumber() &&
     value.data.raw instanceof ObjectValue &&
     value.data.raw.data.length instanceof LiteralValue &&
-    typeof value.data.raw.data.length.data === "number"
+    value.data.raw.data.length.isNumber()
   );
 }

--- a/compiler/src/values/BaseValue.ts
+++ b/compiler/src/values/BaseValue.ts
@@ -51,8 +51,8 @@ export class BaseValue extends VoidValue implements IValue {
   "??"(scope: IScope, other: IValue): TValueInstructions {
     const [left, leftInst] = this.eval(scope);
 
-    const nullLiteral = new LiteralValue(null as never);
-    const endAdress = new LiteralValue(null as never);
+    const nullLiteral = new LiteralValue(null);
+    const endAdress = new LiteralValue(null);
 
     const [nullTest] = left["=="](scope, nullLiteral);
 

--- a/compiler/src/values/FunctionValue.ts
+++ b/compiler/src/values/FunctionValue.ts
@@ -36,7 +36,7 @@ export class FunctionValue extends VoidValue implements IFunctionValue {
   private params: es.Identifier[];
   private paramOwners: ValueOwner<IValue>[] = [];
   private inst!: IInstruction[];
-  private addr!: LiteralValue;
+  private addr!: LiteralValue<number | null>;
   private temp!: ValueOwner<SenseableValue>;
   private ret!: ValueOwner<StoreValue>;
   private inline!: boolean;
@@ -45,7 +45,7 @@ export class FunctionValue extends VoidValue implements IFunctionValue {
   private c: Compiler;
   private callSize!: number;
   private inlineTemp!: ValueOwner<SenseableValue>;
-  private inlineEnd?: LiteralValue;
+  private inlineEnd?: LiteralValue<number | null>;
   private bundled = false;
   private initialized = false;
 
@@ -99,7 +99,7 @@ export class FunctionValue extends VoidValue implements IFunctionValue {
     const { name } = this.owner;
     this.initScope(name);
 
-    this.addr = new LiteralValue(null as never);
+    this.addr = new LiteralValue(null);
     this.temp = new ValueOwner({
       scope: this.childScope,
       name: `${internalPrefix}f${name}`,
@@ -142,7 +142,7 @@ export class FunctionValue extends VoidValue implements IFunctionValue {
   private normalCall(scope: IScope, args: IValue[]): TValueInstructions {
     if (!this.bundled) this.childScope.inst.push(...this.inst);
     this.bundled = true;
-    const callAddressLiteral = new LiteralValue(null as never);
+    const callAddressLiteral = new LiteralValue(null);
     const temp = assign(new SenseableValue(scope), {
       mutability: EMutability.mutable,
     });
@@ -203,7 +203,7 @@ export class FunctionValue extends VoidValue implements IFunctionValue {
       );
     });
 
-    this.inlineEnd = new LiteralValue(null as never);
+    this.inlineEnd = new LiteralValue(null);
 
     this.tryingInline = true;
     let inst = this.c.handle(fnScope, this.body)[1];

--- a/compiler/src/values/LiteralValue.ts
+++ b/compiler/src/values/LiteralValue.ts
@@ -113,10 +113,6 @@ for (const k in operatorMap) {
     scope: IScope,
     value: LiteralValue
   ): TValueInstructions {
-    if (!(value instanceof LiteralValue)) {
-      return BaseValue.prototype[key].apply(this, [scope, value]);
-    }
-
     if (key === "&&") {
       if (this.data) return [value, []];
       return [new LiteralValue(0), []];
@@ -125,6 +121,10 @@ for (const k in operatorMap) {
     if (key === "||") {
       if (!this.data) return [value, []];
       return [new LiteralValue(1), []];
+    }
+
+    if (!(value instanceof LiteralValue)) {
+      return BaseValue.prototype[key].apply(this, [scope, value]);
     }
 
     return [new LiteralValue(fn(this.data as never, value.data as never)), []];

--- a/compiler/src/values/SenseableValue.ts
+++ b/compiler/src/values/SenseableValue.ts
@@ -34,7 +34,7 @@ export class SenseableValue extends StoreValue {
   }
 
   get(scope: IScope, prop: IValue): TValueInstructions<IValue> {
-    if (prop instanceof LiteralValue && typeof prop.data === "string") {
+    if (prop instanceof LiteralValue && prop.isString()) {
       const name = itemNames.includes(prop.data)
         ? camelToDashCase(prop.data)
         : prop.data;

--- a/compiler/test/in/literals.js
+++ b/compiler/test/in/literals.js
@@ -1,5 +1,19 @@
 const a = "string literal";
 const b = true;
 const c = 12;
+const d = false;
 
 print(a, b, c);
+
+const condition = Math.rand(c) > 10;
+
+print(
+  // b should be removed
+  b && condition,
+  // d should be removed
+  d || condition,
+  // evaluates to true
+  b || condition,
+  // evaluates to fales,
+  d && condition
+);

--- a/compiler/test/out/literals.mlog
+++ b/compiler/test/out/literals.mlog
@@ -1,4 +1,10 @@
 print "string literal"
 print 1
 print 12
+op rand &t0 12
+op greaterThan condition:8:6 &t0 10
+print condition:8:6
+print condition:8:6
+print 1
+print 0
 end


### PR DESCRIPTION
Adds some quality of life improvements to the `LiteralValue` class on the compiler side.

And also adds short circuiting for literal values used inside logical expressions with `||` and `&&` (`??` was already supported).

This allows users to do things like use debug flags that can be optimized by the  
compiler.

```js
const debug = false


if(debug && Math.rand(10) > 5) {
  // the expression will always be false
  // so the compiler removes this if block
  print("random debug")
}

```