### PR TITLE
Operation cache

### DIFF
--- a/compiler/src/Scope.ts
+++ b/compiler/src/Scope.ts
@@ -124,8 +124,7 @@ export class Scope implements IScope {
   }
 
   clearDependentCache(value: IValue): void {
-    if (!value.name)
-      throw new CompilerError("Values in the operation cache must have a name");
+    if (!value.name) return;
 
     const dependents = this.cacheDependencies[value.name];
     if (dependents) {

--- a/compiler/src/Scope.ts
+++ b/compiler/src/Scope.ts
@@ -106,6 +106,7 @@ export class Scope implements IScope {
 
     this.operationCache[id] = result;
 
+    this.clearDependentCache(result);
     addCacheDependency(this, left.name, id);
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     if (right) addCacheDependency(this, right.name!, id);

--- a/compiler/src/handlers/OperationExpressions.ts
+++ b/compiler/src/handlers/OperationExpressions.ts
@@ -70,7 +70,6 @@ export const AssignmentExpression: THandler = (
   }
 ) => {
   const [left, leftInst] = c.handle(scope, node.left);
-  if (left) scope.clearDependentCache(left);
   const [right, rightInst] =
     node.operator !== "??="
       ? c.handleEval(
@@ -85,6 +84,7 @@ export const AssignmentExpression: THandler = (
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const [op, opInst] = left![node.operator](scope, right);
+  if (left) scope.clearDependentCache(left);
   return [op, [...leftInst, ...rightInst, ...opInst]];
 };
 

--- a/compiler/src/handlers/OperationExpressions.ts
+++ b/compiler/src/handlers/OperationExpressions.ts
@@ -23,18 +23,23 @@ export const LRExpression: THandler = (
   const [left, leftInst] = c.handleEval(scope, node.left);
   const [right, rightInst] = c.handleEval(scope, node.right);
 
-  const cachedResult = scope.getCachedOperation(node.operator, left, right);
-  if (cachedResult) return [cachedResult, [...leftInst, ...rightInst]];
-
-  // because a * b is the same as b * a
-  if (orderIndependentOperators.includes(node.operator)) {
-    const cachedResult = scope.getCachedOperation(node.operator, right, left);
+  if (!(left instanceof LiteralValue) || !(right instanceof LiteralValue)) {
+    const cachedResult = scope.getCachedOperation(node.operator, left, right);
     if (cachedResult) return [cachedResult, [...leftInst, ...rightInst]];
+
+    // because a * b is the same as b * a
+    if (orderIndependentOperators.includes(node.operator)) {
+      const cachedResult = scope.getCachedOperation(node.operator, right, left);
+      if (cachedResult) return [cachedResult, [...leftInst, ...rightInst]];
+    }
   }
 
   const [op, opInst] = left[node.operator](scope, right, out);
 
-  scope.addCachedOperation(node.operator, op, left, right);
+  if (!(op instanceof LiteralValue)) {
+    scope.addCachedOperation(node.operator, op, left, right);
+  }
+
   return [op, [...leftInst, ...rightInst, ...opInst]];
 };
 

--- a/compiler/src/operators.ts
+++ b/compiler/src/operators.ts
@@ -118,3 +118,16 @@ export const operatorMap: {
   "&&": "land",
   "||": "or",
 } as const;
+
+export const orderIndependentOperators: readonly Operator[] = [
+  "!=",
+  "!==",
+  "&&",
+  "&",
+  "*",
+  "+",
+  "==",
+  "===",
+  "|",
+  "||",
+] as const;

--- a/compiler/src/types.ts
+++ b/compiler/src/types.ts
@@ -76,6 +76,15 @@ export interface IScope {
   function: IFunctionValue;
   /** Counts the number of temp variables generated during compilaton */
   ntemp: number;
+
+  /**
+   * A record of the cached value operations, maps the id
+   * of an operation to a previously computed value.
+   */
+  operationCache: Record<string, IValue>;
+
+  /** Tracks the dependency relation beteween values and cached operations */
+  cacheDependencies: Record<string, string[]>;
   /**
    * Creates a new scope that has `this` as it's parent.
    */
@@ -122,6 +131,28 @@ export interface IScope {
   copy(): IScope;
   /** Creates a temporary mlog variable name */
   makeTempName(): string;
+
+  /** Adds the result of an operation to the local cache */
+  addCachedOperation(
+    op: string,
+    result: IValue,
+    left: IValue,
+    right?: IValue
+  ): void;
+
+  /** Attempts to get an operation cached in this or in a parent scope. */
+  getCachedOperation(
+    op: string,
+    left: IValue,
+    right?: IValue
+  ): IValue | undefined;
+
+  /**
+   * Removes all cached operations dependent on the given value.
+   *
+   * Affects this scope and all of its parents.
+   */
+  clearDependentCache(value: IValue): void;
 }
 
 // we can't use type maps to define actual methods

--- a/compiler/src/values/LiteralValue.ts
+++ b/compiler/src/values/LiteralValue.ts
@@ -33,6 +33,7 @@ export class LiteralValue<T extends TLiteral | null = TLiteral>
   constructor(data: T) {
     super();
     this.data = data;
+    this.name = this.toString();
   }
   eval(_scope: IScope): TValueInstructions {
     return [this, []];

--- a/compiler/test/examples/3dcube.mlog
+++ b/compiler/test/examples/3dcube.mlog
@@ -219,51 +219,27 @@ op sin &t2:rotate:173:0 z:173:22
 op sub &t3:rotate:173:0 0 &t2:rotate:173:0
 op cos &t4:rotate:173:0 x:173:16
 op mul &t5:rotate:173:0 &t3:rotate:173:0 &t4:rotate:173:0
-op cos &t6:rotate:173:0 z:173:22
-op sin &t7:rotate:173:0 y:173:19
-op mul &t8:rotate:173:0 &t6:rotate:173:0 &t7:rotate:173:0
-op sin &t9:rotate:173:0 x:173:16
-op mul &t10:rotate:173:0 &t8:rotate:173:0 &t9:rotate:173:0
-op add b12:152:31 &t5:rotate:173:0 &t10:rotate:173:0
-op sin &t11:rotate:173:0 z:173:22
-op sin &t12:rotate:173:0 x:173:16
-op mul &t13:rotate:173:0 &t11:rotate:173:0 &t12:rotate:173:0
-op cos &t14:rotate:173:0 z:173:22
-op cos &t15:rotate:173:0 x:173:16
-op mul &t16:rotate:173:0 &t14:rotate:173:0 &t15:rotate:173:0
-op sin &t17:rotate:173:0 y:173:19
-op mul &t18:rotate:173:0 &t16:rotate:173:0 &t17:rotate:173:0
-op add b13:152:36 &t13:rotate:173:0 &t18:rotate:173:0
-op sin &t19:rotate:173:0 z:173:22
-op cos &t20:rotate:173:0 y:173:19
-op mul b21:152:41 &t19:rotate:173:0 &t20:rotate:173:0
-op cos &t21:rotate:173:0 z:173:22
-op cos &t22:rotate:173:0 x:173:16
-op mul &t23:rotate:173:0 &t21:rotate:173:0 &t22:rotate:173:0
-op sin &t24:rotate:173:0 z:173:22
-op sin &t25:rotate:173:0 y:173:19
-op mul &t26:rotate:173:0 &t24:rotate:173:0 &t25:rotate:173:0
-op sin &t27:rotate:173:0 x:173:16
-op mul &t28:rotate:173:0 &t26:rotate:173:0 &t27:rotate:173:0
-op add b22:152:46 &t23:rotate:173:0 &t28:rotate:173:0
-op cos &t29:rotate:173:0 z:173:22
-op sub &t30:rotate:173:0 0 &t29:rotate:173:0
-op sin &t31:rotate:173:0 x:173:16
-op mul &t32:rotate:173:0 &t30:rotate:173:0 &t31:rotate:173:0
-op sin &t33:rotate:173:0 z:173:22
-op cos &t34:rotate:173:0 x:173:16
-op mul &t35:rotate:173:0 &t33:rotate:173:0 &t34:rotate:173:0
-op sin &t36:rotate:173:0 y:173:19
-op mul &t37:rotate:173:0 &t35:rotate:173:0 &t36:rotate:173:0
-op add b23:152:51 &t32:rotate:173:0 &t37:rotate:173:0
-op sin &t38:rotate:173:0 y:173:19
-op sub b31:152:56 0 &t38:rotate:173:0
-op cos &t39:rotate:173:0 y:173:19
-op sin &t40:rotate:173:0 x:173:16
-op mul b32:152:61 &t39:rotate:173:0 &t40:rotate:173:0
-op cos &t41:rotate:173:0 y:173:19
-op cos &t42:rotate:173:0 x:173:16
-op mul b33:152:66 &t41:rotate:173:0 &t42:rotate:173:0
-set &rmultiplyMatrices:152:0 268
+op sin &t6:rotate:173:0 y:173:19
+op mul &t7:rotate:173:0 &t0:rotate:173:0 &t6:rotate:173:0
+op sin &t8:rotate:173:0 x:173:16
+op mul &t9:rotate:173:0 &t7:rotate:173:0 &t8:rotate:173:0
+op add b12:152:31 &t5:rotate:173:0 &t9:rotate:173:0
+op mul &t10:rotate:173:0 &t2:rotate:173:0 &t8:rotate:173:0
+op mul &t11:rotate:173:0 &t0:rotate:173:0 &t4:rotate:173:0
+op mul &t12:rotate:173:0 &t11:rotate:173:0 &t6:rotate:173:0
+op add b13:152:36 &t10:rotate:173:0 &t12:rotate:173:0
+op mul b21:152:41 &t2:rotate:173:0 &t1:rotate:173:0
+op mul &t13:rotate:173:0 &t2:rotate:173:0 &t6:rotate:173:0
+op mul &t14:rotate:173:0 &t13:rotate:173:0 &t8:rotate:173:0
+op add b22:152:46 &t11:rotate:173:0 &t14:rotate:173:0
+op sub &t15:rotate:173:0 0 &t0:rotate:173:0
+op mul &t16:rotate:173:0 &t15:rotate:173:0 &t8:rotate:173:0
+op mul &t17:rotate:173:0 &t2:rotate:173:0 &t4:rotate:173:0
+op mul &t18:rotate:173:0 &t17:rotate:173:0 &t6:rotate:173:0
+op add b23:152:51 &t16:rotate:173:0 &t18:rotate:173:0
+op sub b31:152:56 0 &t6:rotate:173:0
+op mul b32:152:61 &t1:rotate:173:0 &t8:rotate:173:0
+op mul b33:152:66 &t1:rotate:173:0 &t4:rotate:173:0
+set &rmultiplyMatrices:152:0 244
 jump 159 always
 set @counter &rrotate:173:0

--- a/compiler/test/examples/breakout.mlog
+++ b/compiler/test/examples/breakout.mlog
@@ -48,25 +48,24 @@ op greaterThan &t13 ballYEnd:70:8 10
 op land &t14 &t12 &t13
 op lessThan &t15 ballY:35:6 15
 op land &t16 &t14 &t15
-jump 59 equal &t16 0
+jump 58 equal &t16 0
 op mul ballVY:37:6 ballVY:37:6 -1.1
 op add &t17 ballX:34:6 2.5
 op sub &t18 &t17 paddleX:31:6
-op div &t19 paddleWidth:30:6 2
-op add &t20 &t18 &t19
-op div &t21 &t20 10
-op add ballVX:36:6 ballVX:36:6 &t21
+op add &t19 &t18 &t0
+op div &t20 &t19 10
+op add ballVX:36:6 ballVX:36:6 &t20
 op sub paddleWidth:30:6 paddleWidth:30:6 1
 set brickPtr:89:8 0
 set y:90:13 126
 op greaterThan &t17 y:90:13 106
-jump 96 equal &t17 0
+jump 95 equal &t17 0
 set x:91:15 1
 op lessThan &t18 x:91:15 176
-jump 94 equal &t18 0
+jump 93 equal &t18 0
 read &t19 bank1 brickPtr:89:8
 op equal &t20 &t19 1
-jump 91 equal &t20 0
+jump 90 equal &t20 0
 draw rect x:91:15 y:90:13 57.666666666666664 9
 op greaterThan &t21 ballXEnd:69:8 x:91:15
 op add &t22 x:91:15 58.666666666666664
@@ -77,7 +76,7 @@ op land &t26 &t24 &t25
 op add &t27 y:90:13 10
 op lessThan &t28 ballY:35:6 &t27
 op land &t29 &t26 &t28
-jump 91 equal &t29 0
+jump 90 equal &t29 0
 write 0 bank1 brickPtr:89:8
 op sub brickCount:40:6 brickCount:40:6 1
 op sub &t30 x:91:15 4
@@ -85,20 +84,20 @@ op greaterThan &t31 ballX:34:6 &t30
 op add &t32 x:91:15 62.666666666666664
 op lessThan &t33 ballX:34:6 &t32
 op land &t34 &t31 &t33
-jump 90 equal &t34 0
+jump 89 equal &t34 0
 op mul ballVY:37:6 ballVY:37:6 -1
-jump 91 always
+jump 90 always
 op mul ballVX:36:6 ballVX:36:6 -1
 op add brickPtr:89:8 brickPtr:89:8 1
 op add x:91:15 x:91:15 58.666666666666664
-jump 64 always
+jump 63 always
 op sub y:90:13 y:90:13 10
-jump 61 always
+jump 60 always
 op lessThan &t17 ballY:35:6 0
 op equal &t18 brickCount:40:6 0
 op or &t19 &t17 &t18
-jump 101 equal &t19 0
-jump 103 always
+jump 100 equal &t19 0
+jump 102 always
 drawflush display1
 jump 17 always
 jump 1 always

--- a/compiler/test/in/operation_caching.js
+++ b/compiler/test/in/operation_caching.js
@@ -1,0 +1,24 @@
+let a = 1;
+
+a + 1;
+
+a + 2;
+
+print`
+a + 2: ${a + 2}
+a + 1: ${a + 1}
+2 + a: ${2 + a}
+1 + a: ${1 + a}
+log2 a: ${Math.log(a) / Math.log(2)}
+`;
+
+if (Math.rand(2) >= 1) {
+  print(Math.rand(2) >= 1);
+  print(Math.log(a) / Math.log(2), "\n");
+  a++;
+  print(Math.log(a) / Math.log(2), "\n");
+}
+
+print(a + 1);
+
+printFlush();

--- a/compiler/test/out/operation_caching.mlog
+++ b/compiler/test/out/operation_caching.mlog
@@ -1,0 +1,34 @@
+set a:1:4 1
+op add &_ a:1:4 1
+op add &_ a:1:4 2
+op add &t0 a:1:4 1
+op log &t1 a:1:4
+op div &t2 &t1 0.6931471805599453
+print "\na + 2: "
+print &_
+print "\na + 1: "
+print &t0
+print "\n2 + a: "
+print &_
+print "\n1 + a: "
+print &t0
+print "\nlog2 a: "
+print &t2
+print "\n"
+op rand &t3 2
+op greaterThanEq &t4 &t3 1
+jump 30 equal &t4 0
+op rand &t5 2
+op greaterThanEq &t6 &t5 1
+print &t6
+print &t2
+print "\n"
+op add a:1:4 a:1:4 1
+op log &t7 a:1:4
+op div &t8 &t7 0.6931471805599453
+print &t8
+print "\n"
+op add &t5 a:1:4 1
+print &t5
+printflush message1
+end


### PR DESCRIPTION
Adds support for operation caching. Closes #126.

The cache is local for each created scope, meaning that an operation being cached only affects the current scope and its children.

Which means that:
```js
// works with `let` too
let a = Math.rand(100)

print(a + 1)

if(a > 50) {
  // cached operations are reused
  print(a > 50, " and ", a + 1)

  // cached operations with `a` are cleared, affects parent scopes
  a  = Math.rand(100)
  
  print(a + 1) // recomputed

}

// recomputed and does NOT reuse the operation inside the if block
// since the cache propagation only occurs from parent to child
print(a + 1)


```

## Limitations
The optimization doesn't work when the 3 or more arguments are reordered:

```js
// although being the same, the compiler can't see that they are equal
a + b + c
a + c + b
// this occurs because the compiler sees those operations like this:
(a + b) + c
(a + c) + b
// and since the expressions are different in the AST, the compiler can't optimize them
// so it's up to the user to write their expressions in a consistent order

```
On another note, this optimization alone reduces the size of the `3dcube` example by 24 instructions.