### PR TITLE
Control flow optimizations

### DIFF
--- a/compiler/src/Compiler.ts
+++ b/compiler/src/Compiler.ts
@@ -58,8 +58,10 @@ export class Compiler {
 
       const valueInst = this.handle(scope, program);
       if (needsEndInstruction(valueInst[1], scope)) {
-        valueInst[1].push(new EndInstruction(), ...scope.inst);
+        valueInst[1].push(new EndInstruction());
       }
+      valueInst[1].push(...scope.inst);
+
       hideRedundantJumps(valueInst[1]);
       this.resolve(valueInst);
       output = this.serialize(valueInst) + "\n";

--- a/compiler/src/handlers/IfStatement.ts
+++ b/compiler/src/handlers/IfStatement.ts
@@ -1,6 +1,6 @@
 import { JumpInstruction, AddressResolver } from "../instructions";
 import { EJumpKind } from "../instructions";
-import { THandler, es, IInstruction } from "../types";
+import { THandler, es, IInstruction, EInstIntent } from "../types";
 import { pipeInsts, withAlwaysRuns } from "../utils";
 import { LiteralValue } from "../values";
 
@@ -15,22 +15,43 @@ export const IfStatement: THandler<null> = (c, scope, node: es.IfStatement) => {
   }
 
   const endIfAddr = new LiteralValue(null);
+  const consequent = withAlwaysRuns(c.handle(scope, node.consequent), false);
 
   inst.push(
     new JumpInstruction(endIfAddr, EJumpKind.Equal, test, new LiteralValue(0)),
-    ...withAlwaysRuns(c.handle(scope, node.consequent), false)[1]
+    ...consequent[1]
   );
 
   if (!node.alternate) {
     inst.push(new AddressResolver(endIfAddr));
   } else {
     const endElseAddr = new LiteralValue(null);
+    const needsJump = !endsWithControlFlow(consequent[1]);
+
+    if (needsJump)
+      inst.push(new JumpInstruction(endElseAddr, EJumpKind.Always));
+
     inst.push(
-      new JumpInstruction(endElseAddr, EJumpKind.Always),
       new AddressResolver(endIfAddr),
-      ...withAlwaysRuns(c.handle(scope, node.alternate), false)[1],
-      new AddressResolver(endElseAddr)
+      ...withAlwaysRuns(c.handle(scope, node.alternate), false)[1]
     );
+
+    if (needsJump) inst.push(new AddressResolver(endElseAddr));
   }
   return [null, inst];
 };
+
+/**
+ * Returns `true` if the instruction array ends with an instruction
+ * that already changes the control flow of the script (like `jump x always`, `end` , `stop`, etc)
+ */
+function endsWithControlFlow(inst: IInstruction[]) {
+  for (let i = inst.length - 1; i >= 0; i--) {
+    const instruction = inst[i];
+    if (instruction instanceof AddressResolver) return false;
+    if (instruction.hidden) continue;
+
+    return instruction.intent !== EInstIntent.none;
+  }
+  return false;
+}

--- a/compiler/src/handlers/Statements.ts
+++ b/compiler/src/handlers/Statements.ts
@@ -5,7 +5,7 @@ import {
   ContinueInstruction,
 } from "../instructions";
 import { es, IScope, IValue, THandler } from "../types";
-import { discardedName } from "../utils";
+import { discardedName, usesAddressResolver } from "../utils";
 import { LazyValue, LiteralValue } from "../values";
 
 export const ExpressionStatement: THandler<IValue | null> = (
@@ -75,7 +75,9 @@ export const LabeledStatement: THandler<null> = (
 
   const [, bodyInst] = c.handle(inner, node.body);
 
-  return [null, [...bodyInst, endAdress]];
+  if (usesAddressResolver(endAdress, bodyInst)) bodyInst.push(endAdress);
+
+  return [null, bodyInst];
 };
 
 function findScopeLabel(scope: IScope, label: string) {

--- a/compiler/src/handlers/SwitchStatement.ts
+++ b/compiler/src/handlers/SwitchStatement.ts
@@ -62,6 +62,7 @@ export const SwitchStatement: THandler<null> = (
     if (comp instanceof LiteralValue) {
       // whether other cases can falltrough and reach this one
       const noFallInto = !canFallInto;
+      const isLastCase = scase === node.cases[node.cases.length - 1];
       if (!comp.data) {
         // this case is not accessible in any way
         if (noFallInto) continue;
@@ -72,7 +73,7 @@ export const SwitchStatement: THandler<null> = (
         if (
           noFallInto &&
           onlyConstantTests &&
-          endsWithoutFalltrough(bodyInst(), endLine)
+          (isLastCase || endsWithoutFalltrough(bodyInst(), endLine))
         ) {
           return [null, [...bodyInst(), endLine]];
         }

--- a/compiler/src/handlers/SwitchStatement.ts
+++ b/compiler/src/handlers/SwitchStatement.ts
@@ -112,7 +112,7 @@ export const SwitchStatement: THandler<null> = (
       ...caseJumps,
       ...(caseJumps.length > 0 && !constantCase ? [defaultJump] : []),
       ...inst,
-      endLine,
+      ...(usesEndLine(endLine, inst) ? [endLine] : []),
     ],
   ];
 };
@@ -137,6 +137,18 @@ function endsWithoutFalltrough(inst: IInstruction[], endLine: AddressResolver) {
       (instruction instanceof BreakInstruction &&
         endLine.bonds.includes(instruction.address))
     );
+  }
+  return false;
+}
+
+function usesEndLine(endLine: AddressResolver, inst: IInstruction[]) {
+  for (let i = inst.length - 1; i >= 0; i--) {
+    const instruction = inst[i];
+    if (
+      instruction instanceof BreakInstruction &&
+      endLine.bonds.includes(instruction.address)
+    )
+      return true;
   }
   return false;
 }

--- a/compiler/src/handlers/WhileStatement.ts
+++ b/compiler/src/handlers/WhileStatement.ts
@@ -64,9 +64,11 @@ export const DoWhileStatement: THandler<null> = (
 
   const childScope = scope.createScope();
   const startLoopAddr = new LiteralValue(null);
+  const endLoopAddr = new LiteralValue(null);
   const startLoopLine = new AddressResolver(startLoopAddr).bindContinue(
     childScope
   );
+  const endLoopLine = new AddressResolver(endLoopAddr).bindBreak(childScope);
 
   if (scope.label) {
     startLoopLine.bindContinue(scope);
@@ -82,6 +84,7 @@ export const DoWhileStatement: THandler<null> = (
         startLoopLine,
         ...bodyLines,
         new JumpInstruction(startLoopAddr, EJumpKind.Always),
+        endLoopLine,
       ],
     ];
   }
@@ -98,6 +101,7 @@ export const DoWhileStatement: THandler<null> = (
         test,
         new LiteralValue(1)
       ),
+      endLoopLine,
     ],
   ];
 };

--- a/compiler/src/instructions/EndInstruction.ts
+++ b/compiler/src/instructions/EndInstruction.ts
@@ -1,6 +1,8 @@
+import { EInstIntent } from "../types";
 import { InstructionBase } from "./InstructionBase";
 
 export class EndInstruction extends InstructionBase {
+  intent = EInstIntent.exit;
   constructor() {
     super("end");
   }

--- a/compiler/src/macros/commands/Stop.ts
+++ b/compiler/src/macros/commands/Stop.ts
@@ -1,8 +1,17 @@
 import { InstructionBase } from "../../instructions";
+import { EInstIntent } from "../../types";
+import { assign } from "../../utils";
 import { MacroFunction } from "../Function";
 
 export class Stop extends MacroFunction<null> {
   constructor() {
-    super(() => [null, [new InstructionBase("stop")]]);
+    super(() => [
+      null,
+      [
+        assign(new InstructionBase("stop"), {
+          intent: EInstIntent.exit,
+        }),
+      ],
+    ]);
   }
 }

--- a/compiler/src/types.ts
+++ b/compiler/src/types.ts
@@ -10,6 +10,11 @@ export enum EInstIntent {
   break,
   continue,
   return,
+  /**
+   * This is used by the `end` and `stop` instructions.
+   * Means that the processor will restart or shutdown.
+   */
+  exit,
 }
 
 export interface IInstruction {

--- a/compiler/src/utils/instruction.ts
+++ b/compiler/src/utils/instruction.ts
@@ -57,3 +57,18 @@ export function pipeInsts<T extends IValue | null>(
   inst.push(...value[1]);
   return value[0];
 }
+
+export function usesAddressResolver(
+  resolver: AddressResolver,
+  instructions: IInstruction[]
+) {
+  for (let i = 0; i < instructions.length; i++) {
+    const inst = instructions[i];
+    if (
+      inst instanceof JumpInstruction &&
+      resolver.bonds.includes(inst.address)
+    )
+      return true;
+  }
+  return false;
+}

--- a/compiler/test/examples/bounce.mlog
+++ b/compiler/test/examples/bounce.mlog
@@ -22,4 +22,3 @@ draw clear 0 0 0
 draw rect x:5:4 y:6:4 5 5
 drawflush display1
 jump 5 always
-end

--- a/compiler/test/examples/breakout.mlog
+++ b/compiler/test/examples/breakout.mlog
@@ -101,4 +101,3 @@ jump 102 always
 drawflush display1
 jump 17 always
 jump 1 always
-end

--- a/compiler/test/examples/clock.mlog
+++ b/compiler/test/examples/clock.mlog
@@ -45,4 +45,3 @@ op mul &t16 &t15 15
 op add &t17 &t16 40
 draw line 40 40 &t14 &t17
 drawflush display1
-end

--- a/compiler/test/examples/pascals_triangle.mlog
+++ b/compiler/test/examples/pascals_triangle.mlog
@@ -35,4 +35,3 @@ print "\n"
 op add i:18:9 i:18:9 1
 jump 5 always
 printflush message1
-end

--- a/compiler/test/in/do_while_break.js
+++ b/compiler/test/in/do_while_break.js
@@ -1,0 +1,6 @@
+let i = 0;
+
+do {
+  if (Math.rand(1) > 0.5) break;
+  i++;
+} while (i < 100);

--- a/compiler/test/in/function_end.js
+++ b/compiler/test/in/function_end.js
@@ -1,0 +1,18 @@
+// tests wether the implicit function return
+// is removed because of the `end`
+// instruction present at the end of the function body
+cubeRoots(-8);
+
+function cubeRoots(number) {
+  // we are not able to calculate
+  // the cube root of negative numbers
+  // so we'll use this workaround instead
+  const sign = number > 0 ? 1 : -1;
+  const p = Math.abs(number) ** (1 / 3) * sign;
+  print`${p} * [cos(0°) + i sen(0°)]\n`;
+  print`${p} * [cos(120°) + i sen(120°)]\n`;
+  print`${p} * [cos(240°) + i sen(240°)]\n`;
+
+  printFlush();
+  endScript();
+}

--- a/compiler/test/out/apply_status.mlog
+++ b/compiler/test/out/apply_status.mlog
@@ -6,4 +6,3 @@ status false tarred unit:3:6 20
 wait 2
 status true overdrive unit:3:6
 wait 3
-end

--- a/compiler/test/out/array_macros.mlog
+++ b/compiler/test/out/array_macros.mlog
@@ -2,4 +2,3 @@ print 5
 print 19
 print 123
 print "foo"
-end

--- a/compiler/test/out/array_macros_des.mlog
+++ b/compiler/test/out/array_macros_des.mlog
@@ -14,4 +14,3 @@ print e:12:5
 print f:12:8
 print g:12:11
 print h:12:14
-end

--- a/compiler/test/out/block_commands.mlog
+++ b/compiler/test/out/block_commands.mlog
@@ -11,4 +11,3 @@ control shoot cyclone1 20 40 1
 control shootp cyclone1 @unit 1
 radar enemy boss flying maxHealth cyclone1 1 &_
 sensor &_ cyclone1 @health
-end

--- a/compiler/test/out/branching.mlog
+++ b/compiler/test/out/branching.mlog
@@ -3,4 +3,3 @@ op greaterThan &t0 i:1:4 10
 jump 4 equal &t0 0
 print "I will always show up in the code"
 print "Stays"
-end

--- a/compiler/test/out/buildings.mlog
+++ b/compiler/test/out/buildings.mlog
@@ -9,4 +9,3 @@ print " : "
 print &t1
 print "\n"
 printflush message1
-end

--- a/compiler/test/out/concat.mlog
+++ b/compiler/test/out/concat.mlog
@@ -1,3 +1,2 @@
 print "first part and second part and third part"
 printflush message1
-end

--- a/compiler/test/out/cutscene.mlog
+++ b/compiler/test/out/cutscene.mlog
@@ -10,4 +10,3 @@ print "Camera controls!"
 message announce 4
 wait 5
 cutscene stop 100 100 0.06 0
-end

--- a/compiler/test/out/do_while.mlog
+++ b/compiler/test/out/do_while.mlog
@@ -4,4 +4,3 @@ print "\n"
 op sub i:1:4 i:1:4 1
 op greaterThan &t0 i:1:4 0
 jump 1 equal &t0 1
-end

--- a/compiler/test/out/do_while_break.mlog
+++ b/compiler/test/out/do_while_break.mlog
@@ -1,0 +1,9 @@
+set i:1:4 0
+op rand &t1 1
+op greaterThan &t2 &t1 0.5
+jump 5 equal &t2 0
+jump 8 always
+op add i:1:4 i:1:4 1
+op lessThan &t0 i:1:4 100
+jump 1 equal &t0 1
+end

--- a/compiler/test/out/do_while_inf.mlog
+++ b/compiler/test/out/do_while_inf.mlog
@@ -9,4 +9,3 @@ jump 9 always
 set &t2 1
 op add i:1:4 i:1:4 &t2
 jump 1 always
-end

--- a/compiler/test/out/do_while_once.mlog
+++ b/compiler/test/out/do_while_once.mlog
@@ -1,4 +1,3 @@
 set i:1:4 0
 print i:1:4
 op add i:1:4 i:1:4 1
-end

--- a/compiler/test/out/drawing.mlog
+++ b/compiler/test/out/drawing.mlog
@@ -9,4 +9,3 @@ draw poly 10 23 8 10 30
 draw rect 20 21 22 23
 draw stroke 15
 draw triangle 10 15 20 25 30 35
-end

--- a/compiler/test/out/end.mlog
+++ b/compiler/test/out/end.mlog
@@ -10,4 +10,3 @@ print "\n"
 op add i:3:9 i:3:9 1
 jump 5 always
 printflush message1
-end

--- a/compiler/test/out/explosion.mlog
+++ b/compiler/test/out/explosion.mlog
@@ -6,4 +6,3 @@ op equal &t0 shooting:3:24 0
 jump 7 equal &t0 0
 end
 explosion @sharded shootX:3:8 shootY:3:16 5 10 1 1 1
-end

--- a/compiler/test/out/expressions.mlog
+++ b/compiler/test/out/expressions.mlog
@@ -39,4 +39,3 @@ print &t8
 op strictEqual &t9 item:22:4 @copper
 op equal &t10 &t9 0
 print &t10
-end

--- a/compiler/test/out/fetch.mlog
+++ b/compiler/test/out/fetch.mlog
@@ -13,4 +13,3 @@ print "\n"
 op add i:3:9 i:3:9 1
 jump 2 always
 printflush message1
-end

--- a/compiler/test/out/flush_message.mlog
+++ b/compiler/test/out/flush_message.mlog
@@ -3,4 +3,3 @@ print "You is a "
 print player:3:6
 message announce 3
 wait 10
-end

--- a/compiler/test/out/function_end.mlog
+++ b/compiler/test/out/function_end.mlog
@@ -1,0 +1,13 @@
+set number:3:19 8
+set &rcubeRoots:3:0 3
+jump 4 always
+end
+op pow rationalPart:6:8 number:3:19 0.3333333333333333
+print rationalPart:6:8
+print " * [cos(0°) + i sen(0°)]\n"
+print rationalPart:6:8
+print " * [cos(120°) + i sen(120°)]\n"
+print rationalPart:6:8
+print " * [cos(240°) + i sen(240°)]\n"
+printflush message1
+end

--- a/compiler/test/out/function_end.mlog
+++ b/compiler/test/out/function_end.mlog
@@ -1,13 +1,20 @@
-set number:3:19 8
-set &rcubeRoots:3:0 3
+set number:6:19 -8
+set &rcubeRoots:6:0 3
 jump 4 always
 end
-op pow rationalPart:6:8 number:3:19 0.3333333333333333
-print rationalPart:6:8
+op greaterThan &t0:cubeRoots:6:0 number:6:19 0
+jump 8 equal &t0:cubeRoots:6:0 0
+set sign:10:8 1
+jump 9 always
+set sign:10:8 -1
+op abs &t1:cubeRoots:6:0 number:6:19
+op pow &t2:cubeRoots:6:0 &t1:cubeRoots:6:0 0.3333333333333333
+op mul p:11:8 &t2:cubeRoots:6:0 sign:10:8
+print p:11:8
 print " * [cos(0°) + i sen(0°)]\n"
-print rationalPart:6:8
+print p:11:8
 print " * [cos(120°) + i sen(120°)]\n"
-print rationalPart:6:8
+print p:11:8
 print " * [cos(240°) + i sen(240°)]\n"
 printflush message1
 end

--- a/compiler/test/out/get_block.mlog
+++ b/compiler/test/out/get_block.mlog
@@ -13,4 +13,3 @@ sensor &t0 building:2:6 @health
 print "the building has "
 print &t0
 print " health"
-end

--- a/compiler/test/out/get_flag.mlog
+++ b/compiler/test/out/get_flag.mlog
@@ -5,4 +5,3 @@ print &t0
 print "\n"
 print &t1
 printflush message1
-end

--- a/compiler/test/out/globals.mlog
+++ b/compiler/test/out/globals.mlog
@@ -272,4 +272,3 @@ print @memory-cell
 print @memory-bank
 print @launch-pad
 print @interplanetary-accelerator
-end

--- a/compiler/test/out/literals.mlog
+++ b/compiler/test/out/literals.mlog
@@ -7,4 +7,3 @@ print condition:8:6
 print condition:8:6
 print 1
 print 0
-end

--- a/compiler/test/out/math.mlog
+++ b/compiler/test/out/math.mlog
@@ -40,4 +40,3 @@ print @radToDeg
 print "\n"
 print @degToRad
 print "\n"
-end

--- a/compiler/test/out/memory.mlog
+++ b/compiler/test/out/memory.mlog
@@ -15,4 +15,3 @@ read &t2 bank1 1
 op add &t3 &t2 1
 write &t3 bank1 1
 printflush message1
-end

--- a/compiler/test/out/misc_commands.mlog
+++ b/compiler/test/out/misc_commands.mlog
@@ -4,4 +4,3 @@ lookup block firstBlock:5:4 0
 lookup item firstItem:6:4 0
 lookup liquid firstLiquid:7:4 0
 lookup unit firstUnit:8:4 0
-end

--- a/compiler/test/out/nested_inlining.mlog
+++ b/compiler/test/out/nested_inlining.mlog
@@ -2,4 +2,3 @@ set a:3:4 5
 set &t1:c:10:0 10
 op mul &t0:b:6:0 5 &t1:c:10:0
 print &t0:b:6:0
-end

--- a/compiler/test/out/object_des.mlog
+++ b/compiler/test/out/object_des.mlog
@@ -38,4 +38,3 @@ sensor b:40:8 &t5 @ammo
 getlink &_ 0
 getlink &t6 1
 sensor &_ &t6 @copper
-end

--- a/compiler/test/out/object_macro.mlog
+++ b/compiler/test/out/object_macro.mlog
@@ -4,4 +4,3 @@ print "number index"
 print "Number is "
 print 20
 printflush message1
-end

--- a/compiler/test/out/operation_caching.mlog
+++ b/compiler/test/out/operation_caching.mlog
@@ -31,4 +31,3 @@ print "\n"
 op add &t5 a:1:4 1
 print &t5
 printflush message1
-end

--- a/compiler/test/out/pack_color.mlog
+++ b/compiler/test/out/pack_color.mlog
@@ -2,4 +2,3 @@ set r:1:4 12
 set b:2:2 245
 packcolor &t0 r:1:4 60 b:2:2 255
 print &t0
-end

--- a/compiler/test/out/print.mlog
+++ b/compiler/test/out/print.mlog
@@ -10,4 +10,3 @@ print "\nusing\ntagged\ntemplates"
 print variable:4:6
 print " emty start and emtpy end "
 print variable:4:6
-end

--- a/compiler/test/out/scopes.mlog
+++ b/compiler/test/out/scopes.mlog
@@ -2,4 +2,3 @@ set foo:1:4 10
 set foo:4:6 15
 print foo:4:6
 print foo:1:4
-end

--- a/compiler/test/out/set_block.mlog
+++ b/compiler/test/out/set_block.mlog
@@ -8,4 +8,3 @@ end
 setblock block @boulder x:3:6 y:3:9 @sharded 0
 setblock floor @metal-floor2 x:3:6 y:3:9 @delerict 0
 setblock ore @ore-copper x:3:6 y:3:9 @delerict 0
-end

--- a/compiler/test/out/set_flag.mlog
+++ b/compiler/test/out/set_flag.mlog
@@ -2,4 +2,3 @@ set flag:1:4 "sodfs"
 op rand &t0 1
 op greaterThan &t1 &t0 0.5
 setflag flag:1:4 &t1
-end

--- a/compiler/test/out/set_rate.mlog
+++ b/compiler/test/out/set_rate.mlog
@@ -1,3 +1,2 @@
 set rate:1:4 10
 setrate rate:1:4
-end

--- a/compiler/test/out/set_rule.mlog
+++ b/compiler/test/out/set_rule.mlog
@@ -21,4 +21,3 @@ setrule waveSending 1 0 0 100 100
 setrule waveSpacing 256 0 0 100 100
 setrule waveTimer 1 0 0 100 100
 setrule waves 1 0 0 100 100
-end

--- a/compiler/test/out/spawn_unit.mlog
+++ b/compiler/test/out/spawn_unit.mlog
@@ -10,4 +10,3 @@ sensor &t1 unit:7:6 @health
 print "available health: "
 print &t1
 printflush message1
-end

--- a/compiler/test/out/spawn_wave.mlog
+++ b/compiler/test/out/spawn_wave.mlog
@@ -6,4 +6,3 @@ op equal &t0 shooting:3:24 0
 jump 7 equal &t0 0
 end
 spawnwave shootX:3:8 shootY:3:16 false
-end

--- a/compiler/test/out/stop.mlog
+++ b/compiler/test/out/stop.mlog
@@ -10,4 +10,3 @@ print "\n"
 op add i:3:9 i:3:9 1
 jump 5 always
 printflush message1
-end

--- a/compiler/test/out/store_equality.mlog
+++ b/compiler/test/out/store_equality.mlog
@@ -3,4 +3,3 @@ getlink b:18:4 0
 print 0
 print 1
 print 0
-end

--- a/compiler/test/out/switch_basic.mlog
+++ b/compiler/test/out/switch_basic.mlog
@@ -1,40 +1,39 @@
 set dynamicItem:1:4 4
 set n:18:19 dynamicItem:1:4
 set &rmatchItem:18:0 4
-jump 20 always
+jump 19 always
 set &t0 &fmatchItem:18:0
 print &t0
 set &t1:matchItem:18:0 @sand
 print &t1:matchItem:18:0
 set item:57:18 @copper
 set &ritemUses:57:0 11
-jump 73 always
+jump 72 always
 set item:57:18 @coal
 set &ritemUses:57:0 14
-jump 73 always
-set item:57:18 @silicon
-set &ritemUses:57:0 17
-jump 73 always
+jump 72 always
+print "Silligone\n"
+print "Something at the end\n"
 print "always runs!\n"
 printflush message1
 end
-jump 37 strictEqual n:18:19 1
-jump 39 strictEqual n:18:19 2
-jump 41 strictEqual n:18:19 3
-jump 43 strictEqual n:18:19 4
-jump 45 strictEqual n:18:19 5
-jump 47 strictEqual n:18:19 6
-jump 49 strictEqual n:18:19 7
-jump 51 strictEqual n:18:19 8
-jump 53 strictEqual n:18:19 9
-jump 55 strictEqual n:18:19 10
-jump 57 strictEqual n:18:19 11
-jump 59 strictEqual n:18:19 12
-jump 61 strictEqual n:18:19 13
-jump 63 strictEqual n:18:19 14
-jump 65 strictEqual n:18:19 15
-jump 67 strictEqual n:18:19 16
-jump 69 always
+jump 36 strictEqual n:18:19 1
+jump 38 strictEqual n:18:19 2
+jump 40 strictEqual n:18:19 3
+jump 42 strictEqual n:18:19 4
+jump 44 strictEqual n:18:19 5
+jump 46 strictEqual n:18:19 6
+jump 48 strictEqual n:18:19 7
+jump 50 strictEqual n:18:19 8
+jump 52 strictEqual n:18:19 9
+jump 54 strictEqual n:18:19 10
+jump 56 strictEqual n:18:19 11
+jump 58 strictEqual n:18:19 12
+jump 60 strictEqual n:18:19 13
+jump 62 strictEqual n:18:19 14
+jump 64 strictEqual n:18:19 15
+jump 66 strictEqual n:18:19 16
+jump 68 always
 set &fmatchItem:18:0 @copper
 set @counter &rmatchItem:18:0
 set &fmatchItem:18:0 @lead
@@ -71,18 +70,18 @@ set &fmatchItem:18:0 null
 set @counter &rmatchItem:18:0
 set &fmatchItem:18:0 null
 set @counter &rmatchItem:18:0
-jump 77 strictEqual item:57:18 @copper
-jump 81 strictEqual item:57:18 @coal
-jump 85 strictEqual item:57:18 @silicon
-jump 86 always
+jump 76 strictEqual item:57:18 @copper
+jump 80 strictEqual item:57:18 @coal
+jump 84 strictEqual item:57:18 @silicon
+jump 85 always
 print "Basic material\n"
 print "Ammo for some units\n"
 print "Duo ammo\n"
-jump 86 always
+jump 85 always
 print "Burn things\n"
 print "Scorch ammo\n"
 print "Energy\n"
-jump 86 always
+jump 85 always
 print "Silligone\n"
 print "Something at the end\n"
 set &fitemUses:57:0 null

--- a/compiler/test/out/switch_basic.mlog
+++ b/compiler/test/out/switch_basic.mlog
@@ -8,10 +8,10 @@ set &t1:matchItem:18:0 @sand
 print &t1:matchItem:18:0
 set item:57:18 @copper
 set &ritemUses:57:0 11
-jump 72 always
+jump 70 always
 set item:57:18 @coal
 set &ritemUses:57:0 14
-jump 72 always
+jump 70 always
 print "Silligone\n"
 print "Something at the end\n"
 print "always runs!\n"
@@ -68,20 +68,18 @@ set &fmatchItem:18:0 @pyratite
 set @counter &rmatchItem:18:0
 set &fmatchItem:18:0 null
 set @counter &rmatchItem:18:0
-set &fmatchItem:18:0 null
-set @counter &rmatchItem:18:0
-jump 76 strictEqual item:57:18 @copper
-jump 80 strictEqual item:57:18 @coal
-jump 84 strictEqual item:57:18 @silicon
-jump 85 always
+jump 74 strictEqual item:57:18 @copper
+jump 78 strictEqual item:57:18 @coal
+jump 82 strictEqual item:57:18 @silicon
+jump 83 always
 print "Basic material\n"
 print "Ammo for some units\n"
 print "Duo ammo\n"
-jump 85 always
+jump 83 always
 print "Burn things\n"
 print "Scorch ammo\n"
 print "Energy\n"
-jump 85 always
+jump 83 always
 print "Silligone\n"
 print "Something at the end\n"
 set &fitemUses:57:0 null

--- a/compiler/test/out/template_strings.mlog
+++ b/compiler/test/out/template_strings.mlog
@@ -10,4 +10,3 @@ d second:4:4 a
 stuff
 print radarResult
 print foo
-end

--- a/compiler/test/out/typescript.mlog
+++ b/compiler/test/out/typescript.mlog
@@ -7,4 +7,3 @@ set foo:17:4 @unknown
 set bar:19:4 foo:17:4
 set baz:21:4 foo:17:4
 set last:23:4 foo:17:4
-end

--- a/compiler/test/out/unit_commands.mlog
+++ b/compiler/test/out/unit_commands.mlog
@@ -16,4 +16,3 @@ ulocate building core 0 @copper coreX:19:16 coreY:19:23 coreFound:19:5 core:19:3
 ulocate ore core true @lead oreX:23:15 oreY:23:21 oreFound:23:5 &_
 ulocate damaged core true @copper dX:24:13 dY:24:17 dFound:24:5 dBuilding:24:21
 ulocate spawn core true @copper sX:25:13 sY:25:17 sFound:25:5 sBuilding:25:21
-end

--- a/compiler/test/out/unit_macro.mlog
+++ b/compiler/test/out/unit_macro.mlog
@@ -22,4 +22,3 @@ sensor &t4 unitA:14:6 @health
 sensor &t5 unitB:20:6 @health
 print &t4
 print &t5
-end

--- a/compiler/test/out/while_loop_inf.mlog
+++ b/compiler/test/out/while_loop_inf.mlog
@@ -6,4 +6,3 @@ jump 7 equal &t1 0
 print i:1:4
 print " ends on zero"
 jump 1 always
-end


### PR DESCRIPTION
Adds optimizations to the `if`, `while`, `swicth` among other statements to only append address resolvers when necessary, this allows the compiler to know if it to adds a return statement to a function or add an `end` instruction at the end of the main code.

Highlights:
-----
```js
foo()

function foo() {
    const value = Math.rand(10)
    if (value > 5) {
        return value * 2
    } else {
        return value / 2
    }
}
```
Before/After:
```diff
set &rfoo:4:0 2
jump 3 always
end
op rand value:5:10 10
op greaterThan &t0:foo:4:0 value:5:10 5
- jump 9 equal &t0:foo:4:0 0
+ jump 8 equal &t0:foo:4:0 0
op mul &ffoo:4:0 value:5:10 2
set @counter &rfoo:4:0
- jump 11 always
op div &ffoo:4:0 value:5:10 2
set @counter &rfoo:4:0
- set &ffoo:4:0 null
- set @counter &rfoo:4:0
```
----
```js
print(1)
```
Before/After:
```diff
print 1
- end
```