### PR TITLE
Jump compression

### DIFF
--- a/compiler/CHANGELOG.md
+++ b/compiler/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed logical expressions creating unnecessary temp values
 - Fixed optional chaning not working on null literals (`null?.foo`).
 - Fixed break statements not working inside `do while` statements.
 - Fixed functions returning values from previous calls.

--- a/compiler/CHANGELOG.md
+++ b/compiler/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added support for compression of the `op` + `jump` instructions.
 - Added optimizations to `if/else` statements that act as guard clauses.
 - Added optimizations to the compiler to only add the `end` instruction when necessary.
 - Added the `setup` subcommand to the CLI.

--- a/compiler/src/handlers/ForStatement.ts
+++ b/compiler/src/handlers/ForStatement.ts
@@ -39,12 +39,7 @@ export const ForStatement: THandler<null> = (
       ...initInst,
       startLoopLine,
       ...testLines,
-      ...JumpInstruction.or(
-        testOut,
-        test,
-        EJumpKind.Equal,
-        new LiteralValue(0)
-      ),
+      ...JumpInstruction.or(test, testOut),
       ...withAlwaysRuns(c.handle(scope, node.body), false)[1],
       beforeEndLine,
       ...updateLines,

--- a/compiler/src/handlers/ForStatement.ts
+++ b/compiler/src/handlers/ForStatement.ts
@@ -40,8 +40,8 @@ export const ForStatement: THandler<null> = (
       startLoopLine,
       ...testLines,
       ...JumpInstruction.or(
-        test,
         testOut,
+        test,
         EJumpKind.Equal,
         new LiteralValue(0)
       ),

--- a/compiler/src/handlers/ForStatement.ts
+++ b/compiler/src/handlers/ForStatement.ts
@@ -2,25 +2,28 @@ import { AddressResolver, JumpInstruction, EJumpKind } from "../instructions";
 import { es, THandler } from "../types";
 import { discardedName, withAlwaysRuns } from "../utils";
 import { LiteralValue } from "../values";
+import { JumpOutValue } from "../values/JumpOutValue";
 
 export const ForStatement: THandler<null> = (
   c,
   parentScope,
   node: es.ForStatement
 ) => {
-  const scope = parentScope.createScope();
-
-  const initInst = node.init ? c.handle(scope, node.init)[1] : [];
-  const [test, testLines] = node.test
-    ? c.handleEval(scope, node.test)
-    : [new LiteralValue(1), []];
-  const updateLines = node.update
-    ? c.handle(scope, node.update, undefined, discardedName)[1]
-    : [];
   const startLoopAddr = new LiteralValue(null);
   // continue statements jump here to run the loop update lines
   const beforeEndAddr = new LiteralValue(null);
   const endLoopAddr = new LiteralValue(null);
+
+  const scope = parentScope.createScope();
+  const testOut = new JumpOutValue(node, endLoopAddr, false);
+
+  const initInst = node.init ? c.handle(scope, node.init)[1] : [];
+  const [test, testLines] = node.test
+    ? c.handleEval(scope, node.test, testOut)
+    : [new LiteralValue(1), []];
+  const updateLines = node.update
+    ? c.handle(scope, node.update, undefined, discardedName)[1]
+    : [];
 
   const startLoopLine = new AddressResolver(startLoopAddr);
   const endLoopLine = new AddressResolver(endLoopAddr).bindBreak(scope);
@@ -36,10 +39,10 @@ export const ForStatement: THandler<null> = (
       ...initInst,
       startLoopLine,
       ...testLines,
-      new JumpInstruction(
-        endLoopAddr,
-        EJumpKind.Equal,
+      ...JumpInstruction.or(
         test,
+        testOut,
+        EJumpKind.Equal,
         new LiteralValue(0)
       ),
       ...withAlwaysRuns(c.handle(scope, node.body), false)[1],

--- a/compiler/src/handlers/IfStatement.ts
+++ b/compiler/src/handlers/IfStatement.ts
@@ -20,10 +20,7 @@ export const IfStatement: THandler<null> = (c, scope, node: es.IfStatement) => {
 
   const consequent = withAlwaysRuns(c.handle(scope, node.consequent), false);
 
-  inst.push(
-    ...JumpInstruction.or(testOut, test, EJumpKind.Equal, new LiteralValue(0)),
-    ...consequent[1]
-  );
+  inst.push(...JumpInstruction.or(test, testOut), ...consequent[1]);
 
   if (!node.alternate) {
     inst.push(new AddressResolver(endIfAddr));

--- a/compiler/src/handlers/IfStatement.ts
+++ b/compiler/src/handlers/IfStatement.ts
@@ -3,10 +3,14 @@ import { EJumpKind } from "../instructions";
 import { THandler, es, IInstruction, EInstIntent } from "../types";
 import { pipeInsts, withAlwaysRuns } from "../utils";
 import { LiteralValue } from "../values";
+import { JumpOutValue } from "../values/JumpOutValue";
 
 export const IfStatement: THandler<null> = (c, scope, node: es.IfStatement) => {
   const inst: IInstruction[] = [];
-  const test = pipeInsts(c.handleEval(scope, node.test), inst);
+  const endIfAddr = new LiteralValue(null);
+  const testOut = new JumpOutValue(node, endIfAddr, false);
+
+  const test = pipeInsts(c.handleEval(scope, node.test, testOut), inst);
 
   if (test instanceof LiteralValue) {
     if (test.data) return [null, c.handle(scope, node.consequent)[1]];
@@ -14,13 +18,13 @@ export const IfStatement: THandler<null> = (c, scope, node: es.IfStatement) => {
     return [null, []];
   }
 
-  const endIfAddr = new LiteralValue(null);
   const consequent = withAlwaysRuns(c.handle(scope, node.consequent), false);
 
   inst.push(
-    new JumpInstruction(endIfAddr, EJumpKind.Equal, test, new LiteralValue(0)),
-    ...consequent[1]
+    ...JumpInstruction.or(test, testOut, EJumpKind.Equal, new LiteralValue(0))
   );
+
+  inst.push(...consequent[1]);
 
   if (!node.alternate) {
     inst.push(new AddressResolver(endIfAddr));

--- a/compiler/src/handlers/IfStatement.ts
+++ b/compiler/src/handlers/IfStatement.ts
@@ -21,10 +21,9 @@ export const IfStatement: THandler<null> = (c, scope, node: es.IfStatement) => {
   const consequent = withAlwaysRuns(c.handle(scope, node.consequent), false);
 
   inst.push(
-    ...JumpInstruction.or(test, testOut, EJumpKind.Equal, new LiteralValue(0))
+    ...JumpInstruction.or(test, testOut, EJumpKind.Equal, new LiteralValue(0)),
+    ...consequent[1]
   );
-
-  inst.push(...consequent[1]);
 
   if (!node.alternate) {
     inst.push(new AddressResolver(endIfAddr));

--- a/compiler/src/handlers/IfStatement.ts
+++ b/compiler/src/handlers/IfStatement.ts
@@ -21,7 +21,7 @@ export const IfStatement: THandler<null> = (c, scope, node: es.IfStatement) => {
   const consequent = withAlwaysRuns(c.handle(scope, node.consequent), false);
 
   inst.push(
-    ...JumpInstruction.or(test, testOut, EJumpKind.Equal, new LiteralValue(0)),
+    ...JumpInstruction.or(testOut, test, EJumpKind.Equal, new LiteralValue(0)),
     ...consequent[1]
   );
 

--- a/compiler/src/handlers/OperationExpressions.ts
+++ b/compiler/src/handlers/OperationExpressions.ts
@@ -50,8 +50,7 @@ export const LogicalExpression: THandler = (
   node: es.LogicalExpression,
   out
 ) => {
-  if (node.operator !== "??")
-    return LRExpression(c, scope, node, undefined, null);
+  if (node.operator !== "??") return LRExpression(c, scope, node, out, null);
 
   const other = new LazyValue((scope, out) =>
     c.handleEval(scope, node.right, out)

--- a/compiler/src/handlers/OperationExpressions.ts
+++ b/compiler/src/handlers/OperationExpressions.ts
@@ -149,8 +149,8 @@ export const ConditionalExpression: THandler = (
     [
       ...testInst,
       ...JumpInstruction.or(
-        test,
         testOut,
+        test,
         EJumpKind.Equal,
         new LiteralValue(0)
       ),

--- a/compiler/src/handlers/OperationExpressions.ts
+++ b/compiler/src/handlers/OperationExpressions.ts
@@ -148,12 +148,7 @@ export const ConditionalExpression: THandler = (
     result,
     [
       ...testInst,
-      ...JumpInstruction.or(
-        testOut,
-        test,
-        EJumpKind.Equal,
-        new LiteralValue(0)
-      ),
+      ...JumpInstruction.or(test, testOut),
       ...consequent[1],
       ...result["="](scope, consequent[0])[1],
       new JumpInstruction(endExpressionAdress, EJumpKind.Always),

--- a/compiler/src/handlers/WhileStatement.ts
+++ b/compiler/src/handlers/WhileStatement.ts
@@ -46,8 +46,8 @@ export const WhileStatement: THandler<null> = (
       startLoopLine,
       ...testLines,
       ...JumpInstruction.or(
-        test,
         testOut,
+        test,
         EJumpKind.Equal,
         new LiteralValue(0)
       ),
@@ -101,8 +101,8 @@ export const DoWhileStatement: THandler<null> = (
       ...bodyLines,
       ...testLines,
       ...JumpInstruction.or(
-        test,
         testOut,
+        test,
         EJumpKind.Equal,
         new LiteralValue(1)
       ),

--- a/compiler/src/handlers/WhileStatement.ts
+++ b/compiler/src/handlers/WhileStatement.ts
@@ -45,12 +45,7 @@ export const WhileStatement: THandler<null> = (
     [
       startLoopLine,
       ...testLines,
-      ...JumpInstruction.or(
-        testOut,
-        test,
-        EJumpKind.Equal,
-        new LiteralValue(0)
-      ),
+      ...JumpInstruction.or(test, testOut),
       ...withAlwaysRuns(c.handle(childScope, node.body), false)[1],
       new JumpInstruction(startLoopAddr, EJumpKind.Always),
       endLoopLine,
@@ -100,12 +95,7 @@ export const DoWhileStatement: THandler<null> = (
       startLoopLine,
       ...bodyLines,
       ...testLines,
-      ...JumpInstruction.or(
-        testOut,
-        test,
-        EJumpKind.Equal,
-        new LiteralValue(1)
-      ),
+      ...JumpInstruction.or(test, testOut),
       ...(usesAddressResolver(endLoopLine, bodyLines) ? [endLoopLine] : []),
     ],
   ];

--- a/compiler/src/instructions/JumpInstruction.ts
+++ b/compiler/src/instructions/JumpInstruction.ts
@@ -1,4 +1,5 @@
 import { IBindableValue, IValue } from "../types";
+import { LiteralValue } from "../values";
 import { JumpOutValue } from "../values/JumpOutValue";
 import { InstructionBase } from "./InstructionBase";
 
@@ -27,19 +28,14 @@ export class JumpInstruction extends InstructionBase {
    * Works with the `JumpOutValue` class to determine
    * wether a jump should be added if the expression wasn't jump compressed.
    */
-  static or(
-    out: JumpOutValue,
-    test: IValue,
-    kind: EJumpKind,
-    right: IValue | (() => IValue)
-  ) {
+  static or(test: IValue, out: JumpOutValue) {
     if (test === out) return [];
     return [
       new JumpInstruction(
         out.address,
-        kind,
+        EJumpKind.Equal,
         test,
-        typeof right === "function" ? right() : right
+        new LiteralValue(+out.whenTrue)
       ),
     ];
   }

--- a/compiler/src/instructions/JumpInstruction.ts
+++ b/compiler/src/instructions/JumpInstruction.ts
@@ -28,8 +28,8 @@ export class JumpInstruction extends InstructionBase {
    * wether a jump should be added if the expression wasn't jump compressed.
    */
   static or(
-    test: IValue,
     out: JumpOutValue,
+    test: IValue,
     kind: EJumpKind,
     right: IValue | (() => IValue)
   ) {

--- a/compiler/src/instructions/JumpInstruction.ts
+++ b/compiler/src/instructions/JumpInstruction.ts
@@ -1,4 +1,5 @@
 import { IBindableValue, IValue } from "../types";
+import { JumpOutValue } from "../values/JumpOutValue";
 import { InstructionBase } from "./InstructionBase";
 
 export enum EJumpKind {
@@ -20,5 +21,26 @@ export class JumpInstruction extends InstructionBase {
     right: IValue | null = null
   ) {
     super("jump", address, kind, left, right);
+  }
+
+  /**
+   * Works with the `JumpOutValue` class to determine
+   * wether a jump should be added if the expression wasn't jump compressed.
+   */
+  static or(
+    test: IValue,
+    out: JumpOutValue,
+    kind: EJumpKind,
+    right: IValue | (() => IValue)
+  ) {
+    if (test === out) return [];
+    return [
+      new JumpInstruction(
+        out.address,
+        kind,
+        test,
+        typeof right === "function" ? right() : right
+      ),
+    ];
   }
 }

--- a/compiler/src/operators.ts
+++ b/compiler/src/operators.ts
@@ -31,10 +31,10 @@ export const binaryOperators = [
   "instanceof",
   "in",
 ] as const;
-export type BinaryOperator = typeof binaryOperators[number];
+export type BinaryOperator = (typeof binaryOperators)[number];
 
 export const logicalOperators = ["&&", "??", "||"] as const;
-export type LogicalOperator = typeof logicalOperators[number];
+export type LogicalOperator = (typeof logicalOperators)[number];
 
 export const arithmeticAssignmentOperators = [
   "%=",
@@ -59,7 +59,7 @@ export const assignmentOperators = [
   ...bitwiseAssignmentOperators,
   "=",
 ] as const;
-export type AssignementOperator = typeof assignmentOperators[number];
+export type AssignementOperator = (typeof assignmentOperators)[number];
 
 export const leftRightOperators = [
   ...binaryOperators,
@@ -67,7 +67,7 @@ export const leftRightOperators = [
   ...assignmentOperators,
 ] as const;
 
-export type LeftRightOperator = typeof leftRightOperators[number];
+export type LeftRightOperator = (typeof leftRightOperators)[number];
 
 export const unaryOperators = [
   "!",
@@ -78,27 +78,22 @@ export const unaryOperators = [
   "void",
   "~",
 ] as const;
-export type UnaryOperator = typeof unaryOperators[number];
+export type UnaryOperator = (typeof unaryOperators)[number];
 
 export const updateOperators = ["++", "--"] as const;
-export type UpdateOperator = typeof updateOperators[number];
+export type UpdateOperator = (typeof updateOperators)[number];
 
 export const singleOperators = [...unaryOperators, ...updateOperators] as const;
 
-export type SingleOperator = typeof singleOperators[number];
+export type SingleOperator = (typeof singleOperators)[number];
 
 export const operators = [...leftRightOperators, ...singleOperators] as const;
-export type Operator = typeof operators[number];
+export type Operator = (typeof operators)[number];
 
-export const operatorMap: {
-  [k in
-    | Exclude<BinaryOperator, "instanceof" | "in">
-    | Exclude<LogicalOperator, "??">]: string;
-} = {
+export const operatorMap = {
   "==": "equal",
   "===": "strictEqual",
   "!=": "notEqual",
-  "!==": "notEqual",
   "<": "lessThan",
   ">": "greaterThan",
   "<=": "lessThanEq",
@@ -117,7 +112,10 @@ export const operatorMap: {
   "<<": "shl",
   "&&": "land",
   "||": "or",
-} as const;
+} as const satisfies Record<
+  Exclude<BinaryOperator | LogicalOperator, "instanceof" | "in" | "!==" | "??">,
+  string
+>;
 
 export const orderIndependentOperators: readonly Operator[] = [
   "!=",

--- a/compiler/src/values/BaseValue.ts
+++ b/compiler/src/values/BaseValue.ts
@@ -8,6 +8,7 @@ import {
   AssignementOperator,
   BinaryOperator,
   LogicalOperator,
+  operatorMap,
   updateOperators,
 } from "../operators";
 import {
@@ -89,33 +90,6 @@ export class BaseValue extends VoidValue implements IValue {
     return [result, [...equalInst, ...resultInst]];
   }
 }
-
-const operatorMap: Record<
-  Exclude<BinaryOperator | LogicalOperator, "instanceof" | "in" | "??" | "!==">,
-  string
-> = {
-  "==": "equal",
-  "===": "strictEqual",
-  "!=": "notEqual",
-  "<": "lessThan",
-  ">": "greaterThan",
-  "<=": "lessThanEq",
-  ">=": "greaterThanEq",
-  "+": "add",
-  "-": "sub",
-  "*": "mul",
-  "/": "div",
-  "%": "mod",
-  "**": "pow",
-  "|": "or",
-  "&": "and",
-  "^": "xor",
-  ">>": "shr",
-  ">>>": "shr",
-  "<<": "shl",
-  "&&": "land",
-  "||": "or",
-} as const;
 
 for (const key in operatorMap) {
   type K = keyof typeof operatorMap;

--- a/compiler/src/values/BaseValue.ts
+++ b/compiler/src/values/BaseValue.ts
@@ -13,6 +13,7 @@ import {
 } from "../operators";
 import {
   EMutability,
+  IInstruction,
   IScope,
   IValue,
   TEOutput,
@@ -20,6 +21,7 @@ import {
 } from "../types";
 import { LiteralValue, VoidValue, StoreValue, SenseableValue } from ".";
 import { pipeInsts } from "../utils";
+import { JumpOutValue } from "./JumpOutValue";
 
 export class BaseValue extends VoidValue implements IValue {
   "u-"(scope: IScope, out?: TEOutput): TValueInstructions {
@@ -39,13 +41,11 @@ export class BaseValue extends VoidValue implements IValue {
   }
 
   "!"(scope: IScope, out?: TEOutput): TValueInstructions {
-    const [that, inst] = this.eval(scope);
-    const temp = StoreValue.from(scope, out);
+    const inst: IInstruction[] = [];
     const falseLiteral = new LiteralValue(0);
-    return [
-      temp,
-      [...inst, new OperationInstruction("equal", temp, that, falseLiteral)],
-    ];
+    const that = pipeInsts(this.eval(scope), inst);
+    const result = pipeInsts(that["=="](scope, falseLiteral, out), inst);
+    return [result, inst];
   }
 
   "~"(scope: IScope, out?: TEOutput): TValueInstructions {
@@ -84,6 +84,12 @@ export class BaseValue extends VoidValue implements IValue {
   }
 
   "!=="(scope: IScope, other: IValue, out?: TEOutput): TValueInstructions {
+    if (out instanceof JumpOutValue && out.canHandle("!==")) {
+      const [left, leftInst] = this.eval(scope);
+      const [right, rightInst] = other.eval(scope);
+      return [out, [...leftInst, ...rightInst, out.handle("!==", left, right)]];
+    }
+
     const [equal, equalInst] = this["==="](scope, other);
     const [result, resultInst] = equal["!"](scope, out);
 
@@ -102,6 +108,12 @@ for (const key in operatorMap) {
   ): TValueInstructions {
     const [left, leftInst] = this.eval(scope);
     const [right, rightInst] = value.eval(scope);
+
+    if (out instanceof JumpOutValue && out.canHandle(key)) {
+      const jump = out.handle(key, left, right);
+      return [out, [...leftInst, ...rightInst, jump]];
+    }
+
     const temp = StoreValue.from(scope, out);
     return [
       temp,

--- a/compiler/src/values/JumpOutValue.ts
+++ b/compiler/src/values/JumpOutValue.ts
@@ -28,6 +28,8 @@ type WhenTrueOperator = Exclude<
 >;
 
 export class JumpOutValue extends VoidValue {
+  macro = true;
+
   constructor(
     public node: es.Node,
     public address: IBindableValue<number | null>,

--- a/compiler/src/values/JumpOutValue.ts
+++ b/compiler/src/values/JumpOutValue.ts
@@ -1,0 +1,111 @@
+import { CompilerError } from "../CompilerError";
+import { EJumpKind, JumpInstruction } from "../instructions";
+import { Operator, operatorMap, comparisonBinaryOperators } from "../operators";
+import {
+  es,
+  IBindableValue,
+  IScope,
+  IValue,
+  TEOutput,
+  TValueInstructions,
+} from "../types";
+import { VoidValue } from "./VoidValue";
+
+const invertedOperatorMap = {
+  "==": operatorMap["!="],
+  "!=": operatorMap["=="],
+  "!==": operatorMap["==="],
+  ">": operatorMap["<="],
+  "<": operatorMap[">="],
+  ">=": operatorMap["<"],
+  "<=": operatorMap[">"],
+} as const satisfies Partial<Record<Operator, string>>;
+
+type WhenFalseOperator = keyof typeof invertedOperatorMap;
+type WhenTrueOperator = Exclude<
+  (typeof comparisonBinaryOperators)[number],
+  "!=="
+>;
+
+export class JumpOutValue extends VoidValue {
+  constructor(
+    public node: es.Node,
+    public address: IBindableValue<number | null>,
+    public whenTrue: boolean
+  ) {
+    super();
+  }
+
+  canHandle(
+    operator: string
+  ): operator is WhenTrueOperator | WhenFalseOperator {
+    if (this.whenTrue) {
+      return (
+        operator in operatorMap &&
+        Object.values(EJumpKind).includes(operatorMap[operator as never])
+      );
+    }
+    return operator in invertedOperatorMap;
+  }
+
+  handle(
+    operator: WhenTrueOperator | WhenFalseOperator,
+    left: IValue,
+    right: IValue
+  ) {
+    let kind: EJumpKind;
+    if (this.whenTrue) {
+      if (operator === "!==")
+        throw new CompilerError('Unsupported jump compression operator "!=="');
+      kind = mapOperator(operator);
+    } else {
+      if (operator === "===")
+        throw new CompilerError('Unsupported jump compression operator "==="');
+      kind = mapInverseOperator(operator);
+    }
+    const jump = new JumpInstruction(this.address, kind, left, right);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    jump.source = this.node.loc!;
+    return jump;
+  }
+
+  eval(_scope: IScope, _out?: TEOutput): TValueInstructions<IValue> {
+    return [this, []];
+  }
+}
+function mapOperator(operator: WhenTrueOperator): EJumpKind {
+  switch (operator) {
+    case "!=":
+      return EJumpKind.NotEqual;
+    case "<":
+      return EJumpKind.LessThan;
+    case "<=":
+      return EJumpKind.LessThanEq;
+    case "==":
+      return EJumpKind.Equal;
+    case "===":
+      return EJumpKind.StrictEqual;
+    case ">":
+      return EJumpKind.GreaterThan;
+    case ">=":
+      return EJumpKind.GreaterThanEq;
+  }
+}
+function mapInverseOperator(operator: WhenFalseOperator): EJumpKind {
+  switch (operator) {
+    case "!=":
+      return EJumpKind.Equal;
+    case "!==":
+      return EJumpKind.StrictEqual;
+    case "<":
+      return EJumpKind.GreaterThanEq;
+    case "<=":
+      return EJumpKind.GreaterThan;
+    case "==":
+      return EJumpKind.NotEqual;
+    case ">":
+      return EJumpKind.LessThanEq;
+    case ">=":
+      return EJumpKind.LessThan;
+  }
+}

--- a/compiler/src/values/LiteralValue.ts
+++ b/compiler/src/values/LiteralValue.ts
@@ -74,11 +74,7 @@ export class LiteralValue<T extends TLiteral | null = TLiteral>
 type TOperationFn = (a: number, b?: number) => number;
 type TBinOperationFn = (a: number, b: number) => number;
 
-const operatorMap: {
-  [k in
-    | Exclude<BinaryOperator, "instanceof" | "in">
-    | Exclude<LogicalOperator, "??">]: TBinOperationFn;
-} = {
+const operatorMap = {
   "==": (a, b) => +(a == b),
   "===": (a, b) => +(a === b),
   "!=": (a, b) => +(a != b),
@@ -101,7 +97,10 @@ const operatorMap: {
   "<<": (a, b) => a << b,
   "&&": (a, b) => +(a && b),
   "||": (a, b) => +(a || b),
-} as const;
+} as const satisfies Record<
+  Exclude<BinaryOperator | LogicalOperator, "instanceof" | "in" | "??">,
+  TBinOperationFn
+>;
 
 for (const k in operatorMap) {
   const key = k as keyof typeof operatorMap;

--- a/compiler/test/examples/breakout.mlog
+++ b/compiler/test/examples/breakout.mlog
@@ -10,8 +10,7 @@ op rand &t2 10
 op sub ballVY:37:6 &t2 5
 set brickCount:40:6 6
 set i:41:11 0
-op lessThan &t3 i:41:11 6
-jump 17 equal &t3 0
+jump 16 greaterThanEq i:41:11 6
 write 1 bank1 i:41:11
 op add i:41:11 i:41:11 1
 jump 12 always
@@ -19,85 +18,79 @@ draw clear 0 0 0
 draw rect paddleX:31:6 10 paddleWidth:30:6 5
 draw rect ballX:34:6 ballY:35:6 5 5
 sensor &t3 switch1 @enabled
-jump 27 equal &t3 0
+jump 25 equal &t3 0
 op sub &t4 176 paddleWidth:30:6
-op lessThan &t5 paddleX:31:6 &t4
-jump 26 equal &t5 0
+jump 24 greaterThanEq paddleX:31:6 &t4
 op add paddleX:31:6 paddleX:31:6 3
-jump 30 always
-op greaterThan &t4 paddleX:31:6 0
-jump 30 equal &t4 0
+jump 27 always
+jump 27 lessThanEq paddleX:31:6 0
 op sub paddleX:31:6 paddleX:31:6 3
 op add ballX:34:6 ballX:34:6 ballVX:36:6
 op add ballY:35:6 ballY:35:6 ballVY:37:6
 op add ballXEnd:69:8 ballX:34:6 5
 op add ballYEnd:70:8 ballY:35:6 5
-op lessThan &t5 ballX:34:6 0
-op greaterThan &t6 ballXEnd:69:8 176
-op or &t7 &t5 &t6
-jump 39 equal &t7 0
+op lessThan &t4 ballX:34:6 0
+op greaterThan &t5 ballXEnd:69:8 176
+op or &t6 &t4 &t5
+jump 36 equal &t6 0
 op mul ballVX:36:6 ballVX:36:6 -1
-op greaterThan &t8 ballYEnd:70:8 176
-jump 42 equal &t8 0
+jump 38 lessThanEq ballYEnd:70:8 176
 op mul ballVY:37:6 ballVY:37:6 -1
-op greaterThan &t9 ballXEnd:69:8 paddleX:31:6
-op add &t10 paddleX:31:6 paddleWidth:30:6
-op lessThan &t11 ballX:34:6 &t10
-op land &t12 &t9 &t11
-op greaterThan &t13 ballYEnd:70:8 10
+op greaterThan &t7 ballXEnd:69:8 paddleX:31:6
+op add &t8 paddleX:31:6 paddleWidth:30:6
+op lessThan &t9 ballX:34:6 &t8
+op land &t10 &t7 &t9
+op greaterThan &t11 ballYEnd:70:8 10
+op land &t12 &t10 &t11
+op lessThan &t13 ballY:35:6 15
 op land &t14 &t12 &t13
-op lessThan &t15 ballY:35:6 15
-op land &t16 &t14 &t15
-jump 58 equal &t16 0
+jump 54 equal &t14 0
 op mul ballVY:37:6 ballVY:37:6 -1.1
-op add &t17 ballX:34:6 2.5
-op sub &t18 &t17 paddleX:31:6
-op add &t19 &t18 &t0
-op div &t20 &t19 10
-op add ballVX:36:6 ballVX:36:6 &t20
+op add &t15 ballX:34:6 2.5
+op sub &t16 &t15 paddleX:31:6
+op add &t17 &t16 &t0
+op div &t18 &t17 10
+op add ballVX:36:6 ballVX:36:6 &t18
 op sub paddleWidth:30:6 paddleWidth:30:6 1
 set brickPtr:89:8 0
 set y:90:13 126
-op greaterThan &t17 y:90:13 106
-jump 95 equal &t17 0
+jump 88 lessThanEq y:90:13 106
 set x:91:15 1
-op lessThan &t18 x:91:15 176
-jump 93 equal &t18 0
-read &t19 bank1 brickPtr:89:8
-op equal &t20 &t19 1
-jump 90 equal &t20 0
+jump 86 greaterThanEq x:91:15 176
+read &t15 bank1 brickPtr:89:8
+jump 83 notEqual &t15 1
 draw rect x:91:15 y:90:13 57.666666666666664 9
-op greaterThan &t21 ballXEnd:69:8 x:91:15
-op add &t22 x:91:15 58.666666666666664
-op lessThan &t23 ballX:34:6 &t22
+op greaterThan &t16 ballXEnd:69:8 x:91:15
+op add &t17 x:91:15 58.666666666666664
+op lessThan &t18 ballX:34:6 &t17
+op land &t19 &t16 &t18
+op greaterThan &t20 ballYEnd:70:8 y:90:13
+op land &t21 &t19 &t20
+op add &t22 y:90:13 10
+op lessThan &t23 ballY:35:6 &t22
 op land &t24 &t21 &t23
-op greaterThan &t25 ballYEnd:70:8 y:90:13
-op land &t26 &t24 &t25
-op add &t27 y:90:13 10
-op lessThan &t28 ballY:35:6 &t27
-op land &t29 &t26 &t28
-jump 90 equal &t29 0
+jump 83 equal &t24 0
 write 0 bank1 brickPtr:89:8
 op sub brickCount:40:6 brickCount:40:6 1
-op sub &t30 x:91:15 4
-op greaterThan &t31 ballX:34:6 &t30
-op add &t32 x:91:15 62.666666666666664
-op lessThan &t33 ballX:34:6 &t32
-op land &t34 &t31 &t33
-jump 89 equal &t34 0
+op sub &t25 x:91:15 4
+op greaterThan &t26 ballX:34:6 &t25
+op add &t27 x:91:15 62.666666666666664
+op lessThan &t28 ballX:34:6 &t27
+op land &t29 &t26 &t28
+jump 82 equal &t29 0
 op mul ballVY:37:6 ballVY:37:6 -1
-jump 90 always
+jump 83 always
 op mul ballVX:36:6 ballVX:36:6 -1
 op add brickPtr:89:8 brickPtr:89:8 1
 op add x:91:15 x:91:15 58.666666666666664
-jump 63 always
+jump 58 always
 op sub y:90:13 y:90:13 10
-jump 60 always
-op lessThan &t17 ballY:35:6 0
-op equal &t18 brickCount:40:6 0
-op or &t19 &t17 &t18
-jump 100 equal &t19 0
-jump 102 always
+jump 56 always
+op lessThan &t15 ballY:35:6 0
+op equal &t16 brickCount:40:6 0
+op or &t17 &t15 &t16
+jump 93 equal &t17 0
+jump 95 always
 drawflush display1
-jump 17 always
+jump 16 always
 jump 1 always

--- a/compiler/test/examples/clock.mlog
+++ b/compiler/test/examples/clock.mlog
@@ -1,19 +1,18 @@
 draw clear 0 0 0
 set i:4:9 0
-op lessThanEq &t0 i:4:9 330
-jump 18 equal &t0 0
-op sin &t1 i:4:9
-op mul x:5:6 &t1 40
-op cos &t2 i:4:9
-op mul y:6:6 &t2 40
+jump 17 greaterThan i:4:9 330
+op sin &t0 i:4:9
+op mul x:5:6 &t0 40
+op cos &t1 i:4:9
+op mul y:6:6 &t1 40
 draw color 75 75 75 255
-op mul &t3 x:5:6 0.8
-op add &t4 &t3 40
-op mul &t5 y:6:6 0.8
-op add &t6 &t5 40
-op add &t7 x:5:6 40
-op add &t8 y:6:6 40
-draw line &t4 &t6 &t7 &t8
+op mul &t2 x:5:6 0.8
+op add &t3 &t2 40
+op mul &t4 y:6:6 0.8
+op add &t5 &t4 40
+op add &t6 x:5:6 40
+op add &t7 y:6:6 40
+draw line &t3 &t5 &t6 &t7
 op add i:4:9 i:4:9 30
 jump 2 always
 op mul h:17:4 @time 0.006

--- a/compiler/test/examples/fibonacci.mlog
+++ b/compiler/test/examples/fibonacci.mlog
@@ -5,20 +5,18 @@ set &t0 &ffibonacci:4:0
 print &t0
 printflush message1
 end
-op lessThanEq &t0:fibonacci:4:0 n:4:19 2
-jump 11 equal &t0:fibonacci:4:0 0
+jump 10 greaterThan n:4:19 2
 set &ffibonacci:4:0 1
 set @counter &rfibonacci:4:0
 set a:7:6 1
 set b:8:6 1
 set c:9:6 2
 set i:11:11 3
-op lessThanEq &t1:fibonacci:4:0 i:11:11 n:4:19
-jump 22 equal &t1:fibonacci:4:0 0
+jump 20 greaterThan i:11:11 n:4:19
 op add c:9:6 a:7:6 b:8:6
 set a:7:6 b:8:6
 set b:8:6 c:9:6
 op add i:11:11 i:11:11 1
-jump 15 always
+jump 14 always
 set &ffibonacci:4:0 c:9:6
 set @counter &rfibonacci:4:0

--- a/compiler/test/examples/pascals_triangle.mlog
+++ b/compiler/test/examples/pascals_triangle.mlog
@@ -3,34 +3,30 @@ set lastSize:12:4 2
 write 1 cell2 0
 write 1 cell2 1
 set i:18:9 3
-op lessThanEq &t0 i:18:9 10
-jump 36 equal &t0 0
+jump 32 greaterThan i:18:9 10
 write 1 cell1 0
 set j:23:11 1
-op lessThan &t1 j:23:11 lastSize:12:4
-jump 18 equal &t1 0
-op sub &t2 j:23:11 1
-read &t3 cell2 &t2
-read &t4 cell2 j:23:11
-op add &t5 &t3 &t4
-write &t5 cell1 j:23:11
+jump 16 greaterThanEq j:23:11 lastSize:12:4
+op sub &t0 j:23:11 1
+read &t1 cell2 &t0
+read &t2 cell2 j:23:11
+op add &t3 &t1 &t2
+write &t3 cell1 j:23:11
 op add j:23:11 j:23:11 1
-jump 9 always
+jump 8 always
 write 1 cell1 lastSize:12:4
 op add lastSize:12:4 lastSize:12:4 1
 set c:30:11 0
-op lessThan &t1 c:30:11 lastSize:12:4
-jump 33 equal &t1 0
-read &t2 cell1 c:30:11
-print &t2
-read &t3 cell1 c:30:11
-write &t3 cell2 c:30:11
-op sub &t4 lastSize:12:4 1
-op lessThan &t5 c:30:11 &t4
-jump 31 equal &t5 0
+jump 29 greaterThanEq c:30:11 lastSize:12:4
+read &t0 cell1 c:30:11
+print &t0
+read &t1 cell1 c:30:11
+write &t1 cell2 c:30:11
+op sub &t2 lastSize:12:4 1
+jump 27 greaterThanEq c:30:11 &t2
 print " "
 op add c:30:11 c:30:11 1
-jump 21 always
+jump 19 always
 print "\n"
 op add i:18:9 i:18:9 1
 jump 5 always

--- a/compiler/test/in/logical_expressions.js
+++ b/compiler/test/in/logical_expressions.js
@@ -1,0 +1,10 @@
+const a = Math.rand(10) > 5;
+const b = Math.rand(10) > 5;
+const c = a && b;
+const d = a || b;
+print`
+a: ${a}
+b: ${b}
+a && b: ${c}
+a || b: ${d}
+`;

--- a/compiler/test/out/branching.mlog
+++ b/compiler/test/out/branching.mlog
@@ -1,5 +1,4 @@
 set i:1:4 1
-op greaterThan &t0 i:1:4 10
-jump 4 equal &t0 0
+jump 3 lessThanEq i:1:4 10
 print "I will always show up in the code"
 print "Stays"

--- a/compiler/test/out/continue_statement.mlog
+++ b/compiler/test/out/continue_statement.mlog
@@ -1,11 +1,10 @@
 set i:1:9 0
-op lessThan &t0 i:1:9 100
-jump 11 equal &t0 0
-op greaterThan &t1 i:1:9 40
-op lessThan &t2 i:1:9 60
-op land &t3 &t1 &t2
-jump 8 equal &t3 0
-jump 9 always
+jump 10 greaterThanEq i:1:9 100
+op greaterThan &t0 i:1:9 40
+op lessThan &t1 i:1:9 60
+op land &t2 &t0 &t1
+jump 7 equal &t2 0
+jump 8 always
 print i:1:9
 op add i:1:9 i:1:9 1
 jump 1 always

--- a/compiler/test/out/cutscene.mlog
+++ b/compiler/test/out/cutscene.mlog
@@ -1,6 +1,5 @@
 sensor &t0 switch1 @enabled
-op equal &t1 &t0 0
-jump 4 equal &t1 0
+jump 3 notEqual &t0 0
 end
 control enabled switch1 0
 cutscene pan 10 10 0.02 0

--- a/compiler/test/out/do_while.mlog
+++ b/compiler/test/out/do_while.mlog
@@ -2,5 +2,4 @@ set i:1:4 10
 print i:1:4
 print "\n"
 op sub i:1:4 i:1:4 1
-op greaterThan &t0 i:1:4 0
-jump 1 equal &t0 1
+jump 1 greaterThan i:1:4 0

--- a/compiler/test/out/do_while_break.mlog
+++ b/compiler/test/out/do_while_break.mlog
@@ -1,9 +1,7 @@
 set i:1:4 0
-op rand &t1 1
-op greaterThan &t2 &t1 0.5
-jump 5 equal &t2 0
-jump 8 always
+op rand &t0 1
+jump 4 lessThanEq &t0 0.5
+jump 6 always
 op add i:1:4 i:1:4 1
-op lessThan &t0 i:1:4 100
-jump 1 equal &t0 1
+jump 1 lessThan i:1:4 100
 end

--- a/compiler/test/out/do_while_inf.mlog
+++ b/compiler/test/out/do_while_inf.mlog
@@ -2,10 +2,9 @@ set i:1:4 0
 print i:1:4
 print "\n"
 op rand &t0 1
-op greaterThan &t1 &t0 0.5
-jump 8 equal &t1 0
-set &t2 2
-jump 9 always
-set &t2 1
-op add i:1:4 i:1:4 &t2
+jump 7 lessThanEq &t0 0.5
+set &t1 2
+jump 8 always
+set &t1 1
+op add i:1:4 i:1:4 &t1
 jump 1 always

--- a/compiler/test/out/dynamic_array.mlog
+++ b/compiler/test/out/dynamic_array.mlog
@@ -8,7 +8,7 @@ set arr:1:6.&len 5
 set &t0 arr:1:6->4
 jump 12 greaterThanEq 4 arr:1:6.&len
 set arr:1:6.&rt 11
-op add @counter 147 4
+op add @counter 144 4
 op sub arr:1:6.&len arr:1:6.&len 1
 print "last: "
 print &t0
@@ -24,7 +24,7 @@ jump 28 lessThan &t3 0
 jump 28 greaterThan &t3 4
 set arr:1:6.&rt 27
 op mul &t5 &t3 2
-op add @counter 153 &t5
+op add @counter 150 &t5
 set &t4 arr:1:6.&gtemp
 print index:6:6
 print ": "
@@ -33,114 +33,111 @@ print "\n"
 printflush message1
 wait 2
 set counter:13:4 0
-op equal &t6 arr:1:6.&len 0
-jump 52 equal &t6 0
+jump 50 notEqual arr:1:6.&len 0
 set i:18:13 1
-op lessThanEq &t7 i:18:13 5
-jump 51 equal &t7 0
-op rand &t8 20
-op add &t9 &t8 1
-op floor &t10 &t9
-op pow &t11 &t10 2
-set arr:1:6.&stemp &t11
-set arr:1:6.&rt 48
-op mul &t12 arr:1:6.&len 2
-op add @counter 163 &t12
+jump 49 greaterThan i:18:13 5
+op rand &t6 20
+op add &t7 &t6 1
+op floor &t8 &t7
+op pow &t9 &t8 2
+set arr:1:6.&stemp &t9
+set arr:1:6.&rt 46
+op mul &t10 arr:1:6.&len 2
+op add @counter 160 &t10
 op add arr:1:6.&len arr:1:6.&len 1
 op add i:18:13 i:18:13 1
-jump 38 always
-jump 129 always
-jump 57 strictEqual counter:13:4 0
-jump 73 strictEqual counter:13:4 1
-jump 91 strictEqual counter:13:4 2
-jump 108 strictEqual counter:13:4 3
+jump 37 always
 jump 127 always
-op rand &t7 arr:1:6.&len
-op floor &t8 &t7
+jump 55 strictEqual counter:13:4 0
+jump 71 strictEqual counter:13:4 1
+jump 89 strictEqual counter:13:4 2
+jump 106 strictEqual counter:13:4 3
+jump 125 always
+op rand &t6 arr:1:6.&len
+op floor &t7 &t6
 set number:26:14 null
-jump 69 lessThan &t8 0
-jump 69 greaterThanEq &t8 arr:1:6.&len
-set arr:1:6.&rt 65
-op mul &t9 &t8 2
-op add @counter 153 &t9
+jump 67 lessThan &t7 0
+jump 67 greaterThanEq &t7 arr:1:6.&len
+set arr:1:6.&rt 63
+op mul &t8 &t7 2
+op add @counter 150 &t8
 set number:26:14 arr:1:6.&gtemp
-set arr:1:6.&rt 68
-op add @counter 147 &t8
+set arr:1:6.&rt 66
+op add @counter 144 &t7
 op sub arr:1:6.&len arr:1:6.&len 1
 print "removed: "
 print number:26:14
 print "\n"
-jump 127 always
-op rand &t7 arr:1:6.&len
-op floor index:32:14 &t7
+jump 125 always
+op rand &t6 arr:1:6.&len
+op floor index:32:14 &t6
 set number:33:14 null
-jump 82 lessThan index:32:14 0
-jump 82 greaterThan index:32:14 4
-set arr:1:6.&rt 81
-op mul &t8 index:32:14 2
-op add @counter 153 &t8
+jump 80 lessThan index:32:14 0
+jump 80 greaterThan index:32:14 4
+set arr:1:6.&rt 79
+op mul &t7 index:32:14 2
+op add @counter 150 &t7
 set number:33:14 arr:1:6.&gtemp
-jump 87 lessThan index:32:14 0
-jump 87 greaterThanEq index:32:14 arr:1:6.&len
-set arr:1:6.&rt 86
-op add @counter 147 index:32:14
+jump 85 lessThan index:32:14 0
+jump 85 greaterThanEq index:32:14 arr:1:6.&len
+set arr:1:6.&rt 84
+op add @counter 144 index:32:14
 op sub arr:1:6.&len arr:1:6.&len 1
 print "removed: "
 print number:33:14
 print "\n"
-jump 127 always
-op sub &t7 arr:1:6.&len 1
-set &t8 null
-jump 104 lessThan &t7 0
-jump 104 greaterThan &t7 4
-set arr:1:6.&rt 98
-op mul &t9 &t7 2
-op add @counter 153 &t9
-set &t8 arr:1:6.&gtemp
+jump 125 always
+op sub &t6 arr:1:6.&len 1
+set &t7 null
+jump 102 lessThan &t6 0
+jump 102 greaterThan &t6 4
+set arr:1:6.&rt 96
+op mul &t8 &t6 2
+op add @counter 150 &t8
+set &t7 arr:1:6.&gtemp
 set arr:1:6.&stemp null
-set arr:1:6.&rt 103
-op mul &t10 &t7 2
-op add @counter 163 &t10
-set arr:1:6.&len &t7
+set arr:1:6.&rt 101
+op mul &t9 &t6 2
+op add @counter 160 &t9
+set arr:1:6.&len &t6
 print "removed: "
-print &t8
+print &t7
 print "\n"
-jump 127 always
-op add &t11 -1 arr:1:6.&len
-set &t12 null
-jump 116 lessThan &t11 0
-jump 116 greaterThan &t11 4
-set arr:1:6.&rt 115
-op mul &t13 &t11 2
-op add @counter 153 &t13
-set &t12 arr:1:6.&gtemp
+jump 125 always
+op add &t10 -1 arr:1:6.&len
+set &t11 null
+jump 114 lessThan &t10 0
+jump 114 greaterThan &t10 4
+set arr:1:6.&rt 113
+op mul &t12 &t10 2
+op add @counter 150 &t12
+set &t11 arr:1:6.&gtemp
 print "removed: "
-print &t12
+print &t11
 print "\n"
-op sub &t14 arr:1:6.&len 1
-jump 127 lessThan &t14 0
-jump 127 greaterThan &t14 4
+op sub &t13 arr:1:6.&len 1
+jump 125 lessThan &t13 0
+jump 125 greaterThan &t13 4
 set arr:1:6.&stemp null
-set arr:1:6.&rt 126
-op mul &t15 &t14 2
-op add @counter 163 &t15
-set arr:1:6.&len &t14
-op add &t7 counter:13:4 1
-op mod counter:13:4 &t7 4
+set arr:1:6.&rt 124
+op mul &t14 &t13 2
+op add @counter 160 &t14
+set arr:1:6.&len &t13
+op add &t6 counter:13:4 1
+op mod counter:13:4 &t6 4
 set i:50:11 0
-op lessThan &t7 i:50:11 arr:1:6.&len
-jump 143 equal &t7 0
-set &t8 null
-jump 139 lessThan i:50:11 0
-jump 139 greaterThan i:50:11 4
-set arr:1:6.&rt 138
-op mul &t9 i:50:11 2
-op add @counter 153 &t9
-set &t8 arr:1:6.&gtemp
-print &t8
+jump 140 greaterThanEq i:50:11 arr:1:6.&len
+set &t6 null
+jump 136 lessThan i:50:11 0
+jump 136 greaterThan i:50:11 4
+set arr:1:6.&rt 135
+op mul &t7 i:50:11 2
+op add @counter 150 &t7
+set &t6 arr:1:6.&gtemp
+print &t6
 print "\n"
 op add i:50:11 i:50:11 1
-jump 130 always
+jump 128 always
 printflush message1
 wait 1.5
 jump 35 always

--- a/compiler/test/out/end.mlog
+++ b/compiler/test/out/end.mlog
@@ -1,12 +1,10 @@
 op rand &t0 1
-op greaterThan &t1 &t0 0.5
-jump 4 equal &t1 0
+jump 3 lessThanEq &t0 0.5
 end
 set i:3:9 0
-op lessThan &t2 i:3:9 10
-jump 11 equal &t2 0
+jump 9 greaterThanEq i:3:9 10
 print i:3:9
 print "\n"
 op add i:3:9 i:3:9 1
-jump 5 always
+jump 4 always
 printflush message1

--- a/compiler/test/out/explosion.mlog
+++ b/compiler/test/out/explosion.mlog
@@ -2,7 +2,6 @@ ubind @gamma
 sensor shootX:3:8 @unit @shootX
 sensor shootY:3:16 @unit @shootY
 sensor shooting:3:24 @unit @shooting
-op equal &t0 shooting:3:24 0
-jump 7 equal &t0 0
+jump 6 notEqual shooting:3:24 0
 end
 explosion @sharded shootX:3:8 shootY:3:16 5 10 1 1 1

--- a/compiler/test/out/expressions.mlog
+++ b/compiler/test/out/expressions.mlog
@@ -1,41 +1,37 @@
 op rand pos:1:6 10
-op lessThan &t0 pos:1:6 2
-jump 5 equal &t0 0
+jump 4 greaterThanEq pos:1:6 2
 set content:3:6 "low"
-jump 14 always
-op lessThan &t1 pos:1:6 4
-jump 9 equal &t1 0
+jump 11 always
+jump 7 greaterThanEq pos:1:6 4
 set content:3:6 "medium"
-jump 14 always
-op lessThan &t2 pos:1:6 6
-jump 13 equal &t2 0
+jump 11 always
+jump 10 greaterThanEq pos:1:6 6
 set content:3:6 "high"
-jump 14 always
+jump 11 always
 set content:3:6 "very high"
 print content:3:6
 op sub offset:8:6 pos:1:6 5
-op sub &t3 0 offset:8:6
-print &t3
+op sub &t0 0 offset:8:6
+print &t0
 print offset:8:6
 print 10
 print "it's false"
-set &t4 offset:8:6
-jump 24 notEqual &t4 null
-set &t4 "offset is null?"
+set &t1 offset:8:6
+jump 21 notEqual &t1 null
+set &t1 "offset is null?"
 print "null is null"
-print &t4
+print &t1
 print "preserved"
-op rand &t5 1
-op greaterThan &t6 &t5 0.5
-jump 32 equal &t6 0
+op rand &t2 1
+jump 28 lessThanEq &t2 0.5
 set item:22:4 null
-jump 33 always
+jump 29 always
 set item:22:4 @beryllium
-jump 35 notEqual item:22:4 null
+jump 31 notEqual item:22:4 null
 set item:22:4 @copper
-op rand &t7 65536
-op not &t8 &t7
-print &t8
-op strictEqual &t9 item:22:4 @copper
-op equal &t10 &t9 0
-print &t10
+op rand &t3 65536
+op not &t4 &t3
+print &t4
+op strictEqual &t5 item:22:4 @copper
+op equal &t6 &t5 0
+print &t6

--- a/compiler/test/out/fetch.mlog
+++ b/compiler/test/out/fetch.mlog
@@ -1,14 +1,13 @@
 fetch buildCount routers:1:6 @sharded 0 @router
 set i:3:9 0
-op lessThan &t0 i:3:9 routers:1:6
-jump 14 equal &t0 0
+jump 13 greaterThanEq i:3:9 routers:1:6
 fetch build router:4:8 @sharded i:3:9 @router
-sensor &t1 router:4:8 @x
-sensor &t2 router:4:8 @y
+sensor &t0 router:4:8 @x
+sensor &t1 router:4:8 @y
 print "x: "
-print &t1
+print &t0
 print " y: "
-print &t2
+print &t1
 print "\n"
 op add i:3:9 i:3:9 1
 jump 2 always

--- a/compiler/test/out/for_loop.mlog
+++ b/compiler/test/out/for_loop.mlog
@@ -1,6 +1,5 @@
 set i:1:9 0
-op lessThan &t0 i:1:9 100
-jump 6 equal &t0 0
+jump 5 greaterThanEq i:1:9 100
 print i:1:9
 op add i:1:9 i:1:9 1
 jump 1 always

--- a/compiler/test/out/function_end.mlog
+++ b/compiler/test/out/function_end.mlog
@@ -2,14 +2,13 @@ set number:6:19 -8
 set &rcubeRoots:6:0 3
 jump 4 always
 end
-op greaterThan &t0:cubeRoots:6:0 number:6:19 0
-jump 8 equal &t0:cubeRoots:6:0 0
+jump 7 lessThanEq number:6:19 0
 set sign:10:8 1
-jump 9 always
+jump 8 always
 set sign:10:8 -1
-op abs &t1:cubeRoots:6:0 number:6:19
-op pow &t2:cubeRoots:6:0 &t1:cubeRoots:6:0 0.3333333333333333
-op mul p:11:8 &t2:cubeRoots:6:0 sign:10:8
+op abs &t0:cubeRoots:6:0 number:6:19
+op pow &t1:cubeRoots:6:0 &t0:cubeRoots:6:0 0.3333333333333333
+op mul p:11:8 &t1:cubeRoots:6:0 sign:10:8
 print p:11:8
 print " * [cos(0°) + i sen(0°)]\n"
 print p:11:8

--- a/compiler/test/out/labels.mlog
+++ b/compiler/test/out/labels.mlog
@@ -1,35 +1,29 @@
 set i:1:16 0
-op lessThan &t0 i:1:16 3
-jump 20 equal &t0 0
+jump 18 greaterThanEq i:1:16 3
 set j:2:11 0
-op lessThan &t1 j:2:11 3
-jump 18 equal &t1 0
-op equal &t2 i:1:16 1
-op equal &t3 j:2:11 1
-op land &t4 &t2 &t3
-jump 11 equal &t4 0
-jump 18 always
+jump 16 greaterThanEq j:2:11 3
+op equal &t0 i:1:16 1
+op equal &t1 j:2:11 1
+op land &t2 &t0 &t1
+jump 9 equal &t2 0
+jump 16 always
 print "i = "
 print i:1:16
 print ", j = "
 print j:2:11
 print "\n"
 op add j:2:11 j:2:11 1
-jump 4 always
+jump 3 always
 op add i:1:16 i:1:16 1
 jump 1 always
 set i:9:4 0
-op lessThan &t0 i:9:4 100
-jump 34 equal &t0 0
+jump 28 greaterThanEq i:9:4 100
 set j:12:6 0
-op equal &t2 i:9:4 j:12:6
-jump 27 equal &t2 0
-jump 34 always
-op lessThan &t3 i:9:4 j:12:6
-jump 30 equal &t3 0
-jump 33 always
+jump 23 notEqual i:9:4 j:12:6
+jump 28 always
+jump 25 greaterThanEq i:9:4 j:12:6
+jump 27 always
 op add j:12:6 j:12:6 1
-op lessThan &t1 j:12:6 100
-jump 24 equal &t1 1
-jump 21 always
+jump 21 lessThan j:12:6 100
+jump 19 always
 end

--- a/compiler/test/out/logical_expressions.mlog
+++ b/compiler/test/out/logical_expressions.mlog
@@ -1,0 +1,15 @@
+op rand &t0 10
+op greaterThan a:1:6 &t0 5
+op rand &t1 10
+op greaterThan b:2:6 &t1 5
+op land c:3:6 a:1:6 b:2:6
+op or d:4:6 a:1:6 b:2:6
+print "\na: "
+print a:1:6
+print "\nb: "
+print b:2:6
+print "\na && b: "
+print c:3:6
+print "\na || b: "
+print d:4:6
+print "\n"

--- a/compiler/test/out/memory.mlog
+++ b/compiler/test/out/memory.mlog
@@ -2,16 +2,15 @@ print "Expecting "
 print 512
 print " bytes to be available"
 read &t0 bank1 0
-op equal &t1 &t0 0
-jump 9 equal &t1 0
+jump 8 notEqual &t0 0
 write 1 bank1 0
 print "Processor intialized"
-jump 16 always
+jump 15 always
 read runs:11:6 bank1 1
 print "This code has run "
 print runs:11:6
 print " time(s)"
-read &t2 bank1 1
-op add &t3 &t2 1
-write &t3 bank1 1
+read &t1 bank1 1
+op add &t2 &t1 1
+write &t2 bank1 1
 printflush message1

--- a/compiler/test/out/operation_caching.mlog
+++ b/compiler/test/out/operation_caching.mlog
@@ -16,18 +16,17 @@ print "\nlog2 a: "
 print &t2
 print "\n"
 op rand &t3 2
-op greaterThanEq &t4 &t3 1
-jump 30 equal &t4 0
-op rand &t5 2
-op greaterThanEq &t6 &t5 1
-print &t6
+jump 29 lessThan &t3 1
+op rand &t4 2
+op greaterThanEq &t5 &t4 1
+print &t5
 print &t2
 print "\n"
 op add a:1:4 a:1:4 1
-op log &t7 a:1:4
-op div &t8 &t7 0.6931471805599453
-print &t8
+op log &t6 a:1:4
+op div &t7 &t6 0.6931471805599453
+print &t7
 print "\n"
-op add &t5 a:1:4 1
-print &t5
+op add &t4 a:1:4 1
+print &t4
 printflush message1

--- a/compiler/test/out/set_block.mlog
+++ b/compiler/test/out/set_block.mlog
@@ -2,8 +2,7 @@ radar player any any distance foreshadow1 1 &t0
 sensor x:3:6 &t0 @x
 sensor y:3:9 &t0 @y
 sensor shooting:3:12 &t0 @shooting
-op equal &t1 shooting:3:12 0
-jump 7 equal &t1 0
+jump 6 notEqual shooting:3:12 0
 end
 setblock block @boulder x:3:6 y:3:9 @sharded 0
 setblock floor @metal-floor2 x:3:6 y:3:9 @delerict 0

--- a/compiler/test/out/spawn_unit.mlog
+++ b/compiler/test/out/spawn_unit.mlog
@@ -2,11 +2,10 @@ ubind @gamma
 sensor shootX:3:8 @unit @shootX
 sensor shootY:3:16 @unit @shootY
 sensor shooting:3:24 @unit @shooting
-op equal &t0 shooting:3:24 0
-jump 7 equal &t0 0
+jump 6 notEqual shooting:3:24 0
 end
 spawn @eclipse shootX:3:8 shootY:3:16 0 @malis unit:7:6
-sensor &t1 unit:7:6 @health
+sensor &t0 unit:7:6 @health
 print "available health: "
-print &t1
+print &t0
 printflush message1

--- a/compiler/test/out/spawn_wave.mlog
+++ b/compiler/test/out/spawn_wave.mlog
@@ -2,7 +2,6 @@ ubind @gamma
 sensor shootX:3:8 @unit @shootX
 sensor shootY:3:16 @unit @shootY
 sensor shooting:3:24 @unit @shooting
-op equal &t0 shooting:3:24 0
-jump 7 equal &t0 0
+jump 6 notEqual shooting:3:24 0
 end
 spawnwave shootX:3:8 shootY:3:16 false

--- a/compiler/test/out/stop.mlog
+++ b/compiler/test/out/stop.mlog
@@ -1,12 +1,10 @@
 op rand &t0 1
-op greaterThan &t1 &t0 0.5
-jump 4 equal &t1 0
+jump 3 lessThanEq &t0 0.5
 stop
 set i:3:9 0
-op lessThan &t2 i:3:9 10
-jump 11 equal &t2 0
+jump 9 greaterThanEq i:3:9 10
 print i:3:9
 print "\n"
 op add i:3:9 i:3:9 1
-jump 5 always
+jump 4 always
 printflush message1

--- a/compiler/test/out/unit_macro.mlog
+++ b/compiler/test/out/unit_macro.mlog
@@ -1,24 +1,23 @@
-op equal &t0 @unit null
-jump 3 equal &t0 0
+jump 2 notEqual @unit null
 ubind @flare
-sensor &t1 @unit @ammo
+sensor &t0 @unit @ammo
 print "ammo: "
+print &t0
+print "\n"
+sensor &t1 @unit @health
+print "health: "
 print &t1
 print "\n"
-sensor &t2 @unit @health
-print "health: "
-print &t2
-print "\n"
 set item:10:4 @copper
-sensor &t3 @unit item:10:4
+sensor &t2 @unit item:10:4
 print "amount of "
 print item:10:4
 print " : "
-print &t3
+print &t2
 printflush message1
 radar enemy any any distance cyclone1 1 unitA:14:6
 uradar enemy flying any distance 0 1 unitB:20:6
-sensor &t4 unitA:14:6 @health
-sensor &t5 unitB:20:6 @health
+sensor &t3 unitA:14:6 @health
+sensor &t4 unitB:20:6 @health
+print &t3
 print &t4
-print &t5

--- a/compiler/test/out/while_loop.mlog
+++ b/compiler/test/out/while_loop.mlog
@@ -1,6 +1,5 @@
 set i:1:4 0
-op lessThan &t0 i:1:4 100
-jump 6 equal &t0 0
+jump 5 greaterThanEq i:1:4 100
 print i:1:4
 op add i:1:4 i:1:4 1
 jump 1 always

--- a/compiler/test/out/while_loop_break.mlog
+++ b/compiler/test/out/while_loop_break.mlog
@@ -1,10 +1,8 @@
 set i:1:4 0
-op lessThan &t0 i:1:4 100
-jump 9 equal &t0 0
-op rand &t1 1
-op greaterThan &t2 &t1 0.5
-jump 7 equal &t2 0
-jump 9 always
+jump 7 greaterThanEq i:1:4 100
+op rand &t0 1
+jump 5 lessThanEq &t0 0.5
+jump 7 always
 op add i:1:4 i:1:4 1
 jump 1 always
 end

--- a/compiler/test/out/while_loop_inf.mlog
+++ b/compiler/test/out/while_loop_inf.mlog
@@ -1,8 +1,7 @@
 set i:1:4 0
 print "data"
 op mod &t0 i:1:4 10
-op equal &t1 &t0 0
-jump 7 equal &t1 0
+jump 6 notEqual &t0 0
 print i:1:4
 print " ends on zero"
 jump 1 always


### PR DESCRIPTION
Adds an optimization for statements and expressions that generate jump comparisons:

```js
let a = Math.rand(10);
let b = Math.rand(10);

if (a > b) {
  print("a > b");
} else {
  print("b >= a");
}
printFlush();
```

Before/After:

```diff
op rand a:1:4 10
op rand b:2:4 10
- op greaterThan &t0 a:1:4 b:2:4
- jump 6 equal &t0 0
+ jump 5 lessThanEq a:1:4 b:2:4
print "a > b"
jump 7 always
print "b >= a"
printflush message1
```

Closes #119,