### PR TITLE
Refactor object patterns

### DIFF
--- a/compiler/lib/commands.d.ts
+++ b/compiler/lib/commands.d.ts
@@ -455,7 +455,7 @@ declare global {
      * }
      * ```
      */
-    function unit(index: number): UnitSymbol | null;
+    function unit(index: number): UnitSymbol | undefined;
 
     /**
      * Looks up an item symbol by it's index on the content registry.
@@ -469,7 +469,7 @@ declare global {
      * }
      * ```
      */
-    function item(index: number): ItemSymbol | null;
+    function item(index: number): ItemSymbol | undefined;
 
     /**
      * Looks up a liquid symbol by it's index on the content registry.
@@ -483,7 +483,7 @@ declare global {
      * }
      * ```
      */
-    function liquid(index: number): LiquidSymbol | null;
+    function liquid(index: number): LiquidSymbol | undefined;
   }
 
   /**
@@ -710,9 +710,9 @@ declare global {
       x: number,
       y: number
     ): [
-      type: BlockSymbol | null,
-      building: T | null,
-      floor: EnvBlockSymbol | OreSymbol | null
+      type: BlockSymbol | undefined,
+      building: T | undefined,
+      floor: EnvBlockSymbol | OreSymbol | undefined
     ];
 
     /**
@@ -891,11 +891,11 @@ declare global {
     /** Gets the block type on the give location. `Blocks.air` if there is no block. */
     function block(x: number, y: number): BlockSymbol;
 
-    /** Gets the building on the given location. `null` if there is no building. */
+    /** Gets the building on the given location. `undefined` if there is no building. */
     function building<T extends BasicBuilding = AnyBuilding>(
       x: number,
       y: number
-    ): T | null;
+    ): T | undefined;
   }
 
   /**  Sets block data on a given location. World processor ONLY.  */

--- a/compiler/lib/macros.d.ts
+++ b/compiler/lib/macros.d.ts
@@ -60,7 +60,7 @@ declare class DynamicArray<T> extends MutableArray<T> {
   constructor(length: number);
 
   /**
-   * Sets the last item of the array to `null` and decreases its length by 1.
+   * Sets the last item of the array to `undefined` and decreases its length by 1.
    *
    * This method only generates the instructions for getting the value when needed.
    *

--- a/compiler/lib/traits.d.ts
+++ b/compiler/lib/traits.d.ts
@@ -23,7 +23,7 @@ declare global {
         readonly [I in keyof typeof Items]: number;
       } & {
         readonly totalItems: number;
-        readonly firstItem: ItemSymbol | null;
+        readonly firstItem?: ItemSymbol;
         readonly itemCapacity: number;
       }
     > {}
@@ -120,13 +120,13 @@ declare global {
 
   interface Nameable
     extends WithSymbols<{
-      readonly name: string | null;
+      readonly name?: string;
     }> {}
 
   interface PayloadHolder
     extends WithSymbols<{
       readonly payloadCount: number;
-      readonly payloadType: symbol | null;
+      readonly payloadType?: symbol;
     }> {}
 
   interface WithEnable
@@ -134,7 +134,7 @@ declare global {
       enabled: boolean;
     }> {}
   interface WithConfig<
-    T extends symbol | number | null = symbol | null
+    T extends symbol | number | undefined = symbol | undefined
   > extends WithSymbols<{
       readonly config: T;
     }> {}

--- a/compiler/src/handlers/Literal.ts
+++ b/compiler/src/handlers/Literal.ts
@@ -1,3 +1,4 @@
+import { CompilerError } from "../CompilerError";
 import { THandler, es } from "../types";
 import { LiteralValue } from "../values";
 
@@ -10,7 +11,11 @@ const Literal: THandler = (
 export const NumericLiteral = Literal;
 export const StringLiteral = Literal;
 
-export const NullLiteral: THandler = () => [new LiteralValue(null), []];
+export const NullLiteral: THandler = () => {
+  throw new CompilerError(
+    "`null` is no longer supported, use `undefined` instead"
+  );
+};
 
 export const BooleanLiteral: THandler = (
   _c,

--- a/compiler/src/handlers/Object.ts
+++ b/compiler/src/handlers/Object.ts
@@ -138,14 +138,7 @@ export const ArrayPattern: THandler = (c, scope, node: es.ArrayPattern) => {
             pipeInsts(value["="](scope, inst[0]), inst[1]);
             return inst;
           }
-
-          const inst: IInstruction[] = [];
-          const evaluated = pipeInsts(
-            value.right.eval(scope, value.left),
-            inst
-          );
-          const result = pipeInsts(value.left["="](scope, evaluated), inst);
-          return [result, inst];
+          return value["="](scope, new LiteralValue(null));
         });
       },
     });
@@ -188,11 +181,11 @@ export const ObjectPattern: THandler = (c, scope, node: es.ObjectPattern) => {
             const output = pipeInsts(value["="](scope, input), inst);
             return [output, inst];
           }
-          const evaluated = pipeInsts(
-            value.right.eval(scope, value.left),
+
+          const result = pipeInsts(
+            value["="](scope, new LiteralValue(null)),
             inst
           );
-          const result = pipeInsts(value.left["="](scope, evaluated), inst);
           return [result, inst];
         });
       },

--- a/compiler/src/handlers/VariableDeclaration.ts
+++ b/compiler/src/handlers/VariableDeclaration.ts
@@ -227,14 +227,14 @@ const DeclareObjectPattern: TDeclareHandler<es.ObjectPattern> = (
             );
           }
 
-          return [init, initInst];
+          return [init, [...keyInst[1], ...initInst]];
         });
 
         return value.handler(init, inst);
       },
     });
 
-    return [null, [...keyInst[1], ...valueInst]];
+    return [null, valueInst];
   });
 
   const out = new DestructuringValue(members);

--- a/compiler/src/handlers/VariableDeclaration.ts
+++ b/compiler/src/handlers/VariableDeclaration.ts
@@ -85,8 +85,7 @@ const DeclareIdentifier: TDeclareHandler<es.Identifier> = (
 ) => {
   const { name: identifier } = node;
   const name = nodeName(node, !c.compactNames && identifier);
-  const out = SenseableValue.from(
-    scope,
+  const out = new SenseableValue(
     name,
     kind === "const" ? EMutability.init : EMutability.mutable
   );

--- a/compiler/src/handlers/VariableDeclaration.ts
+++ b/compiler/src/handlers/VariableDeclaration.ts
@@ -213,7 +213,7 @@ const DeclareObjectPattern: TDeclareHandler<es.ObjectPattern> = (
     members.set(keyInst[0], {
       value: value.out,
       handler(get, propExists) {
-        const [init, inst] = c.handle(scope, propValue, () => {
+        const [init, inst] = c.handle(scope, prop, () => {
           let [init, initInst] =
             propExists() || !value.defaultInit
               ? get()

--- a/compiler/src/handlers/VariableDeclaration.ts
+++ b/compiler/src/handlers/VariableDeclaration.ts
@@ -139,22 +139,9 @@ const DeclareArrayPattern: TDeclareHandler<es.ArrayPattern> = (
 
     members.set(new LiteralValue(i), {
       value: value.out,
-      handler(get) {
+      handler(get, propExists) {
         return c.handle(scope, element, () => {
-          let [init, initInst]: TValueInstructions<IValue | null> = [null, []];
-
-          try {
-            [init, initInst] = get();
-          } catch (e) {
-            // catches the "cannot get undefined member" error
-            // TODO: refactor and add error codes
-            // so we don't have to do string checks
-            if (
-              !(e instanceof CompilerError) ||
-              !e.message.includes("is not present in")
-            )
-              throw e;
-          }
+          const [init, initInst] = propExists() ? get() : [null, []];
 
           if (!init)
             throw new CompilerError(

--- a/compiler/src/initScope.ts
+++ b/compiler/src/initScope.ts
@@ -12,11 +12,13 @@ import { GetGlobal } from "./macros/GetGlobal";
 import { Scope } from "./Scope";
 import { EMutability } from "./types";
 import { Asm } from "./macros/Asm";
+import { LiteralValue } from "./values";
 
 /**
  * Adds all the compiler globals to `scope`
  */
 export function initScope(scope: Scope) {
+  scope.hardSet("undefined", new LiteralValue(null));
   // namespaces
   scope.hardSet("ControlKind", new NamespaceMacro());
   scope.hardSet("Vars", new VarsNamespace());

--- a/compiler/src/macros/DynamicArray.ts
+++ b/compiler/src/macros/DynamicArray.ts
@@ -294,6 +294,7 @@ export class DynamicArray extends ObjectValue {
     if (prop instanceof LiteralValue && prop.isNumber()) {
       return prop.data >= 0 && prop.data < this.values.length;
     }
+    if (prop instanceof StoreValue) return true;
 
     return super.hasProperty(scope, prop);
   }

--- a/compiler/src/macros/Memory.ts
+++ b/compiler/src/macros/Memory.ts
@@ -78,7 +78,11 @@ class MemoryMacro extends ObjectValue {
   }
 
   hasProperty(scope: IScope, prop: IValue): boolean {
-    if (prop instanceof LiteralValue && prop.isNumber()) return true;
+    if (
+      (prop instanceof LiteralValue && prop.isNumber()) ||
+      prop instanceof StoreValue
+    )
+      return true;
     return super.hasProperty(scope, prop);
   }
 

--- a/compiler/src/types.ts
+++ b/compiler/src/types.ts
@@ -263,6 +263,13 @@ export interface IValue extends IValueOperators {
   get(scope: IScope, name: IValue, out?: TEOutput): TValueInstructions;
 
   /**
+   * Wether `this` has a given property.
+   * This method is used to know if it's safe to get a
+   * field of an object without errors.
+   */
+  hasProperty(scope: IScope, prop: IValue): boolean;
+
+  /**
    * A hook that the CallExpression and related handlers call
    * before evaluating the function parameters.
    */

--- a/compiler/src/values/AssignmentValue.ts
+++ b/compiler/src/values/AssignmentValue.ts
@@ -1,0 +1,32 @@
+import {
+  IInstruction,
+  IScope,
+  IValue,
+  TEOutput,
+  TValueInstructions,
+} from "../types";
+import { pipeInsts } from "../utils";
+import { VoidValue } from "./VoidValue";
+
+export class AssignmentValue extends VoidValue {
+  constructor(public left: IValue, public right: IValue) {
+    super();
+    this.name = left.name;
+  }
+
+  "="(scope: IScope, value: IValue, out?: TEOutput): TValueInstructions {
+    const inst: IInstruction[] = [];
+    const input = pipeInsts(value["??"](scope, this.right, this.left), inst);
+    const output = pipeInsts(this.left["="](scope, input, out), inst);
+
+    return [output, inst];
+  }
+
+  debugString(): string {
+    return "AssignmentValue";
+  }
+
+  toString(): string {
+    return '"[macro AssignmentValue]"';
+  }
+}

--- a/compiler/src/values/BaseValue.ts
+++ b/compiler/src/values/BaseValue.ts
@@ -57,11 +57,6 @@ export class BaseValue extends VoidValue implements IValue {
   // requires special handling
   // the handler should give an object value to allow the lazy evaluation
   "??"(scope: IScope, other: IValue, out?: TEOutput): TValueInstructions {
-    if (this instanceof LiteralValue) {
-      if (this.data === null) return other.eval(scope, out);
-      return [this, []];
-    }
-
     const result = SenseableValue.from(scope, out, EMutability.mutable);
 
     const [left, leftInst] = this.eval(scope, result);

--- a/compiler/src/values/BaseValue.ts
+++ b/compiler/src/values/BaseValue.ts
@@ -20,7 +20,7 @@ import {
   TValueInstructions,
 } from "../types";
 import { LiteralValue, VoidValue, StoreValue, SenseableValue } from ".";
-import { pipeInsts } from "../utils";
+import { discardedName, pipeInsts } from "../utils";
 import { JumpOutValue } from "./JumpOutValue";
 
 export class BaseValue extends VoidValue implements IValue {
@@ -168,12 +168,12 @@ for (const key of updateOperators) {
     out?: TEOutput
   ): TValueInstructions {
     let [ret, inst] = this.eval(scope);
-    if (!prefix) {
-      const temp = StoreValue.out(scope, out);
-      const tempValue = pipeInsts(temp["="](scope, ret), inst);
-      ret = tempValue;
+    if (!prefix && out !== discardedName) {
+      const temp = StoreValue.from(scope, out);
+      ret = pipeInsts(temp["="](scope, ret), inst);
     }
     const kind = key === "++" ? "+=" : "-=";
-    return [ret, [...inst, ...this[kind](scope, new LiteralValue(1))[1]]];
+    pipeInsts(this[kind](scope, new LiteralValue(1)), inst);
+    return [ret, inst];
   };
 }

--- a/compiler/src/values/DestructuringValue.ts
+++ b/compiler/src/values/DestructuringValue.ts
@@ -14,7 +14,6 @@ export type TDestructuringMembers = Map<
       get: () => TValueInstructions,
       propExists: () => boolean
     ): TValueInstructions<IValue | null>;
-    default?(): TValueInstructions;
   }
 >;
 

--- a/compiler/src/values/DestructuringValue.ts
+++ b/compiler/src/values/DestructuringValue.ts
@@ -10,7 +10,11 @@ export type TDestructuringMembers = Map<
     /**
      * Handles the input value, is responsible for the assignment.
      */
-    handler(get: () => TValueInstructions): TValueInstructions<IValue | null>;
+    handler(
+      get: () => TValueInstructions,
+      propExists: () => boolean
+    ): TValueInstructions<IValue | null>;
+    default?(): TValueInstructions;
   }
 >;
 
@@ -48,7 +52,10 @@ export class DestructuringValue extends VoidValue {
 
     for (const [key, { value, handler }] of this.members) {
       pipeInsts(
-        handler(() => right.get(scope, key, value)),
+        handler(
+          () => right.get(scope, key, value),
+          () => right.hasProperty(scope, key)
+        ),
         inst
       );
     }

--- a/compiler/src/values/FunctionValue.ts
+++ b/compiler/src/values/FunctionValue.ts
@@ -29,22 +29,38 @@ import { LiteralValue } from "./LiteralValue";
 import { StoreValue } from "./StoreValue";
 import { VoidValue } from "./VoidValue";
 import { SenseableValue } from "./SenseableValue";
+import { LazyValue } from "./LazyValue";
+import { AssignmentValue } from "./AssignmentValue";
+import {
+  DestructuringValue,
+  TDestructuringMembers,
+} from "./DestructuringValue";
 
 export type TFunctionValueInitParams = (childScope: IScope) => {
   paramStores: StoreValue[];
   paramNames: string[];
 };
+
+type FunctionParam = es.Function["params"][number];
+type TParamValue = SenseableValue | AssignmentValue | DestructuringValue;
+
 export class FunctionValue extends VoidValue implements IFunctionValue {
   name: string;
   mutability = EMutability.constant;
   macro = true;
 
   scope: IScope;
-  private out?: TEOutput;
   private childScope!: IScope;
-  private params: es.Identifier[];
-  private paramValues: IValue[] = [];
-  private paramNames: string[] = [];
+  private params: FunctionParam[];
+  private paramValues: TParamValue[] = [];
+  private paramNames: Map<TParamValue, string> = new Map();
+  private destructuringKeyData: Map<
+    IValue,
+    { inst: IInstruction[]; value: TParamValue }
+  > = new Map();
+  private paramOuts: IValue[] = [];
+  private minimumArgumentCount = 0;
+  private maximumArgumentCount = 0;
   private inst!: IInstruction[];
   private addr!: LiteralValue<number | null>;
   private temp!: SenseableValue;
@@ -77,7 +93,6 @@ export class FunctionValue extends VoidValue implements IFunctionValue {
     this.body = body;
     this.c = c;
     this.params = params;
-    this.out = out;
     this.name = extractOutName(out) ?? scope.makeTempName();
   }
 
@@ -88,14 +103,19 @@ export class FunctionValue extends VoidValue implements IFunctionValue {
   private initScope() {
     this.childScope = this.scope.createFunction(this.name);
     this.childScope.function = this;
-    for (const id of this.params) {
-      const name = nodeName(id, !this.c.compactNames && id.name);
-      const value = new SenseableValue(name, EMutability.mutable);
-      this.childScope.set(id.name, value);
+
+    for (let i = 0; i < this.params.length; i++) {
+      const value = this.unwrapParameter(this.params[i]);
       this.paramValues.push(value);
-      this.paramNames.push(id.name);
+      this.paramOuts.push(
+        value instanceof AssignmentValue ? value.left : value
+      );
+
+      if (!(value instanceof AssignmentValue))
+        this.minimumArgumentCount = i + 1;
     }
     this.callSize = this.paramValues.length + 2;
+    this.maximumArgumentCount = this.params.length;
   }
   private ensureInit() {
     if (this.initialized) return;
@@ -159,7 +179,9 @@ export class FunctionValue extends VoidValue implements IFunctionValue {
       : SenseableValue.from(scope, undefined, EMutability.mutable);
 
     const inst: IInstruction[] = this.paramValues
-      .map((param, i) => param["="](scope, args[i])[1])
+      .map(
+        (param, i) => param["="](scope, args[i] ?? new LiteralValue(null))[1]
+      )
       .reduce((s, c) => s.concat(c), [])
       .concat(
         ...this.ret["="](scope, callAddressLiteral)[1],
@@ -209,15 +231,19 @@ export class FunctionValue extends VoidValue implements IFunctionValue {
 
     // make a copy of the function scope
     const fnScope = this.childScope.copy();
+
+    this.tryingInline = true;
+    let inst: IInstruction[] = [];
     // hard set variables within the function scope
-    this.paramNames.forEach((name, i) => {
-      fnScope.hardSet(name, args[i]);
-    });
+    for (let i = 0; i < this.paramValues.length; i++) {
+      inst.push(
+        ...this.hardSetParameter(fnScope, this.paramValues[i], args[i])
+      );
+    }
 
     this.inlineEnd = new LiteralValue(null);
 
-    this.tryingInline = true;
-    let inst = this.c.handle(fnScope, this.body)[1];
+    inst.push(...this.c.handle(fnScope, this.body)[1]);
     this.tryingInline = false;
 
     const returnIndex = inst.findIndex(
@@ -236,10 +262,21 @@ export class FunctionValue extends VoidValue implements IFunctionValue {
 
   call(scope: IScope, args: IValue[], out?: TEOutput): TValueInstructions {
     this.ensureInit();
-    if (args.length !== this.paramNames.length)
+    if (
+      args.length < this.minimumArgumentCount ||
+      args.length > this.maximumArgumentCount
+    ) {
+      const min = this.minimumArgumentCount;
+      const max = this.maximumArgumentCount;
+      if (min !== max)
+        throw new CompilerError(
+          `Cannot call: expected ${min}-${max} arguments but got: ${args.length}`
+        );
       throw new CompilerError(
-        `Cannot call: expected ${this.paramNames.length} arguments but got: ${args.length}`
+        `Cannot call: expected ${min} arguments but got: ${args.length}`
       );
+    }
+    validateParameters(args, this.paramValues);
     const inlineCall = this.inlineCall(scope, args, out);
     hideRedundantJumps(inlineCall[1]);
     const inlineSize = inlineCall[1].filter(i => !i.hidden).length;
@@ -264,7 +301,7 @@ export class FunctionValue extends VoidValue implements IFunctionValue {
   preCall(): readonly IValue[] | undefined {
     this.ensureInit();
     if (this.inline || this.tryingInline) return;
-    return this.paramValues;
+    return this.paramOuts;
   }
 
   debugString(): string {
@@ -273,6 +310,159 @@ export class FunctionValue extends VoidValue implements IFunctionValue {
 
   toString() {
     return '"[macro FunctionValue]"';
+  }
+
+  private unwrapParameter(param: FunctionParam): TParamValue {
+    switch (param.type) {
+      case "Identifier": {
+        const name = nodeName(param, !this.c.compactNames && param.name);
+        const value = new SenseableValue(name, EMutability.mutable);
+        this.childScope.set(param.name, value);
+        this.paramNames.set(value, param.name);
+
+        return value;
+      }
+      case "AssignmentPattern": {
+        const left = this.unwrapParameter(param.left as FunctionParam);
+
+        const [rightValue, rightInst] = this.c.handleEval(
+          this.childScope,
+          param.right,
+          left
+        );
+        const right = new LazyValue(scope => {
+          if (this.inline || this.tryingInline) {
+            return this.c.handleEval(scope, param.right, left);
+          }
+          return [rightValue, [...rightInst]];
+        });
+
+        return new AssignmentValue(left, right);
+      }
+      case "ObjectPattern": {
+        const members: TDestructuringMembers = new Map();
+        for (const prop of param.properties) {
+          if (prop.type === "RestElement")
+            throw new CompilerError("Rest parameters are not supported");
+
+          const { key: propKey, value: propValue } = prop;
+          const propInst: IInstruction[] = [];
+
+          const key =
+            propKey.type === "Identifier" && !prop.computed
+              ? new LiteralValue(propKey.name)
+              : pipeInsts(
+                  this.c.handleEval(this.childScope, propKey),
+                  propInst
+                );
+
+          const value = this.unwrapParameter(propValue as FunctionParam);
+          const hasDefault = value instanceof AssignmentValue;
+          this.destructuringKeyData.set(key, { inst: propInst, value });
+
+          members.set(key, {
+            value: hasDefault ? value.left : value,
+            handler: (get, propExists) => {
+              return this.c.handle(this.childScope, prop, () => {
+                const inst = [...propInst];
+                if (propExists() || !hasDefault) {
+                  const input = pipeInsts(get(), inst);
+                  // assigns the output to the target value
+                  const output = pipeInsts(
+                    value["="](this.childScope, input),
+                    inst
+                  );
+                  return [output, inst];
+                }
+                const result = pipeInsts(
+                  value["="](this.childScope, new LiteralValue(null)),
+                  inst
+                );
+                return [result, inst];
+              });
+            },
+          });
+        }
+        return new DestructuringValue(members);
+      }
+      case "ArrayPattern": {
+        const members: TDestructuringMembers = new Map();
+
+        for (let i = 0; i < param.elements.length; i++) {
+          const element = param.elements[i];
+          if (!element) continue;
+          const value = this.unwrapParameter(element as FunctionParam);
+          const hasDefault = value instanceof AssignmentValue;
+
+          if (!value)
+            throw new CompilerError(
+              "Destructuring element must resolve to a value",
+              element
+            );
+
+          const key = new LiteralValue(i);
+
+          this.destructuringKeyData.set(key, { inst: [], value });
+          members.set(key, {
+            value: hasDefault ? value.left : value,
+            handler: (get, propExists) => {
+              return this.c.handle(this.childScope, element, () => {
+                if (propExists() || !hasDefault) {
+                  const inst = get();
+                  // assigns the output to the target value
+                  pipeInsts(value["="](this.childScope, inst[0]), inst[1]);
+                  return inst;
+                }
+
+                return value["="](this.childScope, new LiteralValue(null));
+              });
+            },
+          });
+        }
+        return new DestructuringValue(members);
+      }
+      default:
+        throw new CompilerError(
+          `Unsupported function parameter type: ${param.type}`
+        );
+    }
+  }
+
+  private hardSetParameter(
+    scope: IScope,
+    param: TParamValue,
+    value: IValue = new LiteralValue(null)
+  ): IInstruction[] {
+    if (param instanceof SenseableValue) {
+      const name = this.paramNames.get(param) as string;
+      scope.hardSet(name, value);
+      return [];
+    }
+
+    if (param instanceof AssignmentValue) {
+      const [result, inst] = value["??"](scope, param.right, param.left);
+
+      inst.push(
+        ...this.hardSetParameter(scope, param.left as TParamValue, result)
+      );
+
+      return inst;
+    }
+
+    const inst: IInstruction[] = [];
+    for (const [key, { value: out }] of param.members) {
+      const data = this.destructuringKeyData.get(key);
+      if (!data) continue;
+      inst.push(...data.inst);
+      const hasDefault = data.value instanceof AssignmentValue;
+      const input =
+        value.hasProperty(scope, key) || !hasDefault
+          ? pipeInsts(value.get(scope, key, out), inst)
+          : new LiteralValue(null);
+      inst.push(...this.hardSetParameter(scope, data.value, input));
+    }
+
+    return inst;
   }
 }
 
@@ -295,4 +485,20 @@ function endsWithReturn(fun: FunctionValue, inst: IInstruction[]) {
     );
   }
   return false;
+}
+
+function validateParameters(args: IValue[], params: IValue[]) {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const param = params[i];
+    if (
+      arg instanceof StoreValue &&
+      param instanceof AssignmentValue &&
+      param.left.macro
+    ) {
+      throw new CompilerError(
+        "Cannot pass a store to a function parameter that has a macro as a default value."
+      );
+    }
+  }
 }

--- a/compiler/src/values/LiteralValue.ts
+++ b/compiler/src/values/LiteralValue.ts
@@ -65,6 +65,11 @@ export class LiteralValue<T extends TLiteral | null = TLiteral>
     return this.data;
   }
 
+  "??"(scope: IScope, other: IValue, out?: TEOutput): TValueInstructions {
+    if (this.data === null) return other.eval(scope, out);
+    return [this, []];
+  }
+
   typeof(): TValueInstructions {
     return [new LiteralValue("literal"), []];
   }

--- a/compiler/src/values/LiteralValue.ts
+++ b/compiler/src/values/LiteralValue.ts
@@ -52,6 +52,13 @@ export class LiteralValue<T extends TLiteral | null = TLiteral>
       );
     return [method.apply(this, [scope]), []];
   }
+
+  hasProperty(scope: IScope, prop: IValue): boolean {
+    if (this.isString() && prop instanceof LiteralValue && prop.isString())
+      return Object.prototype.hasOwnProperty.call(literalMethods, prop.data);
+    return false;
+  }
+
   get num() {
     if (this.data === null) return 0;
     if (typeof this.data === "string") return 1;

--- a/compiler/src/values/ObjectValue.ts
+++ b/compiler/src/values/ObjectValue.ts
@@ -96,6 +96,12 @@ export class ObjectValue extends VoidValue {
     return $call.call(scope, args, out);
   }
 
+  "??"(scope: IScope, other: IValue, out?: TEOutput): TValueInstructions {
+    const $ = this.data["$??"];
+    if ($) return $.call(scope, [other], out);
+    return [this, []];
+  }
+
   debugString(): string {
     if (this.name) return `ObjectValue("${this.name}")`;
     return "ObjectValue";
@@ -107,6 +113,7 @@ export class ObjectValue extends VoidValue {
 }
 
 for (const op of leftRightOperators) {
+  if (op === "??") continue;
   ObjectValue.prototype[op] = function (
     this: ObjectValue,
     scope: IScope,

--- a/compiler/src/values/SenseableValue.ts
+++ b/compiler/src/values/SenseableValue.ts
@@ -80,4 +80,11 @@ export class SenseableValue extends StoreValue {
   debugString(): string {
     return `SenseableValue("${this.name}")`;
   }
+
+  hasProperty(scope: IScope, prop: IValue): boolean {
+    return (
+      (prop instanceof LiteralValue && prop.isString()) ||
+      prop instanceof StoreValue
+    );
+  }
 }

--- a/compiler/src/values/VoidValue.ts
+++ b/compiler/src/values/VoidValue.ts
@@ -32,6 +32,10 @@ export class VoidValue implements IValue {
     );
   }
 
+  hasProperty(_scope: IScope, _prop: IValue): boolean {
+    return false;
+  }
+
   preCall(_scope: IScope, _out?: TEOutput): readonly TEOutput[] | undefined {
     return;
   }

--- a/compiler/src/values/index.ts
+++ b/compiler/src/values/index.ts
@@ -6,3 +6,4 @@ export * from "./ObjectValue";
 export * from "./SenseableValue";
 export * from "./DestructuringValue";
 export * from "./LazyValue";
+export * from "./AssignmentValue";

--- a/compiler/test/in/computed_destructuring.js
+++ b/compiler/test/in/computed_destructuring.js
@@ -1,0 +1,10 @@
+let { [calculate(1)]: a = calculate(2), [calculate(3)]: b = calculate(4) } =
+  new MutableArray([5, 4, 3, 2, 1]);
+
+print`a: ${a}, b: ${b}`;
+printFlush();
+
+function calculate(n) {
+  print`calculating ${n}\n`;
+  return n;
+}

--- a/compiler/test/in/expressions.js
+++ b/compiler/test/in/expressions.js
@@ -14,12 +14,12 @@ print(1 + 2 > 1.4 ? 10 : -5);
 print(1 + 1 != 2 ? "huh, true" : "it's false");
 
 print(
-  null ?? "null is null",
+  undefined ?? "undefined is null",
   offset ?? "offset is null?",
   "preserved" ?? "should not appear"
 );
 
-let item = Math.rand(1) > 0.5 ? null : Items.beryllium;
+let item = Math.rand(1) > 0.5 ? undefined : Items.beryllium;
 
 item ??= Items.copper;
 

--- a/compiler/test/in/switch_basic.js
+++ b/compiler/test/in/switch_basic.js
@@ -50,7 +50,7 @@ function matchItem(n) {
     case 16:
       return Items.pyratite;
     default:
-      return null;
+      return undefined;
   }
 }
 

--- a/compiler/test/in/typescript.ts
+++ b/compiler/test/in/typescript.ts
@@ -14,7 +14,7 @@ print(
   State.incremented
 );
 
-let foo = getVar<number | symbol | null>("@unknown");
+let foo = getVar<number | symbol | undefined>("@unknown");
 
 let bar = foo as number;
 

--- a/compiler/test/in/unit_macro.js
+++ b/compiler/test/in/unit_macro.js
@@ -1,7 +1,7 @@
 // Doing this is needed because typescript
 // will otherwise infer the type of Vars.unit to be never
 const unit = Vars.unit;
-if (unit == null) {
+if (unit == undefined) {
   unitBind(Units.flare);
 }
 print("ammo: ", Vars.unit.ammo, "\n");

--- a/compiler/test/out/computed_destructuring.mlog
+++ b/compiler/test/out/computed_destructuring.mlog
@@ -1,0 +1,58 @@
+set &t2->0 5
+set &t2->1 4
+set &t2->2 3
+set &t2->3 2
+set &t2->4 1
+set n:7:19 1
+set &rcalculate:7:0 8
+jump 43 always
+set &t0 &fcalculate:7:0
+set a:1:22 null
+jump 16 lessThan &t0 0
+jump 16 greaterThan &t0 4
+set &t2.&rt 15
+op mul &t3 &t0 2
+op add @counter 48 &t3
+set a:1:22 &t2.&gtemp
+jump 21 notEqual a:1:22 null
+set n:7:19 2
+set &rcalculate:7:0 20
+jump 43 always
+set a:1:22 &fcalculate:7:0
+set n:7:19 3
+set &rcalculate:7:0 24
+jump 43 always
+set &t1 &fcalculate:7:0
+set b:1:56 null
+jump 32 lessThan &t1 0
+jump 32 greaterThan &t1 4
+set &t2.&rt 31
+op mul &t4 &t1 2
+op add @counter 48 &t4
+set b:1:56 &t2.&gtemp
+jump 37 notEqual b:1:56 null
+set n:7:19 4
+set &rcalculate:7:0 36
+jump 43 always
+set b:1:56 &fcalculate:7:0
+print "a: "
+print a:1:22
+print ", b: "
+print b:1:56
+printflush message1
+end
+print "calculating "
+print n:7:19
+print "\n"
+set &fcalculate:7:0 n:7:19
+set @counter &rcalculate:7:0
+set &t2.&gtemp &t2->0
+set @counter &t2.&rt
+set &t2.&gtemp &t2->1
+set @counter &t2.&rt
+set &t2.&gtemp &t2->2
+set @counter &t2.&rt
+set &t2.&gtemp &t2->3
+set @counter &t2.&rt
+set &t2.&gtemp &t2->4
+set @counter &t2.&rt

--- a/compiler/test/out/expressions.mlog
+++ b/compiler/test/out/expressions.mlog
@@ -19,7 +19,7 @@ print "it's false"
 set &t1 offset:8:6
 jump 21 notEqual &t1 null
 set &t1 "offset is null?"
-print "null is null"
+print "undefined is null"
 print &t1
 print "preserved"
 op rand &t2 1

--- a/website/docs/guide/commands.md
+++ b/website/docs/guide/commands.md
@@ -874,12 +874,12 @@ Gets block data from the map. Available ONLY for world processors.
 
 - #### `getBlock.building`
 
-  Gets the building on the given location. `null` if there is no building.
+  Gets the building on the given location. `undefined` if there is no building.
 
   ```js
   const building = getBlock.building(10, 20);
 
-  if (building != null) {
+  if (building != undefined) {
     print("found ", building, "");
   } else {
     print("no building found");

--- a/website/docs/guide/syntax-support.md
+++ b/website/docs/guide/syntax-support.md
@@ -284,7 +284,7 @@ Limitations:
 ### Null coalescing operator
 
 The null coalescing operator (`??`) allows you to lazily evaluated the right side
-of the expression when the left side is `null`.
+of the expression when the left side is `undefined`.
 
 ```js
 const sorter = getBuilding("sorter1");
@@ -296,7 +296,7 @@ const itemToFetch = sorter.config ?? Items.graphite;
 
 Behavior:
 
-- Evaluates the left side, if it resolves to `null` it evaluates the right side and returns its value
+- Evaluates the left side, if it resolves to `undefined` it evaluates the right side and returns its value
 
 ### Ternary operator (conditional expression)
 
@@ -449,4 +449,4 @@ You can declare custom type aliases and interfaces. Since the compiler does not 
 
 ### Non null assertions
 
-Again, this one is ignored by the compiler, use it to make typescript happy, though most of the time you should check if nullable variables are `null` before using them.
+Again, this one is ignored by the compiler, use it to make typescript happy, though most of the time you should check if nullable variables are `undefined` before using them.


### PR DESCRIPTION
Reworks how patterns (destructuring and default values) work with the compiler.

Most importantly the compiler now uses `undefined` as its "null" value, that way default function parameters can be implemented and so can default destructuring values.

Closes #90.