### PR TITLE
Allow dynamic memory length

### DIFF
--- a/compiler/CHANGELOG.md
+++ b/compiler/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `Memory` macros can now be created with a dynamic `length` value.
 - (Breaking) `undefined` replaced `null` as the nullish value in the compiler.
 - `unitBind` now also accepts an unit object as a parameter.
 - Error messages now include information about the type of the variables.


### PR DESCRIPTION
Since `Memory` can take a dynamic building, it makes sense to allow it to take a dynamic length.

With this pull request, the following code is now valid:
```js
const cell = getBuilding("cell1");
const bank = getBuilding("bank1");

const mem = new Memory(bank ?? cell, bank ? 512 : 64);
print(mem.length);
printFlush();
```
