### PR TITLE
Concat template strings

### DIFF
--- a/compiler/CHANGELOG.md
+++ b/compiler/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added support for `concat` calls with tagged template literals.
 - Added support for the typescript `satisfies` keyword.
 - Added support for default destructuring values.
 - Added support for the `draw.col` command overload.

--- a/compiler/lib/helpers.d.ts
+++ b/compiler/lib/helpers.d.ts
@@ -20,8 +20,24 @@ declare function getBuilding<T extends BasicBuilding = AnyBuilding>(
   name: string
 ): T;
 
-/** Concatenates a list of constant strings */
-declare function concat(...strings: string[]): string;
+/**
+ * Concatenates a list of constant literal values.
+ *
+ * ```js
+ * const name = "example";
+ *
+ * // works with normal arguments
+ * const before = concat("before_", name);
+ *
+ * // works with tagged template strings
+ * const after = concat`after_${name}`;
+ * ```
+ */
+declare function concat(
+  ...args:
+    | (string | number | undefined)[]
+    | [TemplateStringsArray, ...(string | number | undefined)[]]
+): string;
 
 /**
  * Inlines raw mlog code. Variables and expressions can be placed inside.

--- a/compiler/src/handlers/TemplateExpression.ts
+++ b/compiler/src/handlers/TemplateExpression.ts
@@ -3,6 +3,6 @@ import { THandler } from "../types";
 
 export const TemplateLiteral: THandler<null> = () => {
   throw new CompilerError(
-    "Template strings are currently unavailable. To inline mlog code use the asm function."
+    "Template strings can only be used in tagged template literals. To inline mlog code use the asm function."
   );
 };

--- a/compiler/src/macros/Other.ts
+++ b/compiler/src/macros/Other.ts
@@ -1,20 +1,46 @@
 import { LiteralValue } from "../values";
-import { IValue } from "../types";
+import { IValue, TValueInstructions } from "../types";
 import { MacroFunction } from "./Function";
 import { CompilerError } from "../CompilerError";
+import { isTemplateObjectArray } from "../utils";
 
 export class Concat extends MacroFunction {
   constructor() {
     super((scope, out, ...values: IValue[]) => {
-      for (const value of values)
-        if (!(value instanceof LiteralValue))
-          throw new CompilerError(
-            "Concat arguments must all be literal values."
-          );
-      return [
-        new LiteralValue(values.map(v => (v as LiteralValue).data).join("")),
-        [],
-      ];
+      const [first] = values;
+      if (!isTemplateObjectArray(first)) {
+        assertLiterals(values, "Concat arguments must be all literal values");
+        return [new LiteralValue(values.map(v => v.data).join("")), []];
+      }
+
+      let text = "";
+
+      const [, ...interpolated] = values;
+      assertLiterals(
+        interpolated,
+        "Interpolated values in concat must be literals"
+      );
+
+      for (let i = 0; i < values.length; i++) {
+        const [string] = first.get(
+          scope,
+          new LiteralValue(i)
+        ) as TValueInstructions<LiteralValue>;
+
+        text += string.data;
+        if (i < interpolated.length) text += interpolated[i].data;
+      }
+
+      return [new LiteralValue(text), []];
     });
+  }
+}
+
+function assertLiterals(
+  values: IValue[],
+  message: string
+): asserts values is LiteralValue[] {
+  for (const value of values) {
+    if (!(value instanceof LiteralValue)) throw new CompilerError(message);
   }
 }

--- a/compiler/test/in/concat.js
+++ b/compiler/test/in/concat.js
@@ -3,4 +3,5 @@ const second = "second part and ";
 const third = "third part";
 
 print(concat(first, second, third));
+print`${concat`${first}${second}${third}`}`;
 printFlush(getBuilding("message1"));

--- a/compiler/test/out/concat.mlog
+++ b/compiler/test/out/concat.mlog
@@ -1,2 +1,3 @@
 print "first part and second part and third part"
+print "first part and second part and third part"
 printflush message1

--- a/website/docs/guide/helper-methods.md
+++ b/website/docs/guide/helper-methods.md
@@ -47,14 +47,16 @@ end
 
 ## `concat`
 
-Allows you to concatenate a series of constant strings.
+Concatenates a list of constant literal values.
 
 ```js
-const programVersion = "2";
-const programName = "special-program";
-const fullName = concat(programName, "-v", programVersion);
+const name = "example";
 
-// ...
+// works with normal arguments
+const before = concat("before_", name);
+
+// works with tagged template strings
+const after = concat`after_${name}`;
 ```
 
 ## `asm`


### PR DESCRIPTION
Adds support for tagged template expressions with the `concat` helper method.

With this pull request the following code is now valid:

```js
const name = "script_name"
const extension = ".ts"
const finalName = concat`${name}.${extension}`
```