### PR TITLE
Optimize `if` statements that contain `break` or `continue`

### DIFF
--- a/compiler/test/examples/breakout.mlog
+++ b/compiler/test/examples/breakout.mlog
@@ -89,8 +89,7 @@ jump 56 always
 op lessThan &t15 ballY:35:6 0
 op equal &t16 brickCount:40:6 0
 op or &t17 &t15 &t16
-jump 93 equal &t17 0
-jump 95 always
+jump 94 equal &t17 1
 drawflush display1
 jump 16 always
 jump 1 always

--- a/compiler/test/out/continue_statement.mlog
+++ b/compiler/test/out/continue_statement.mlog
@@ -1,10 +1,9 @@
 set i:1:9 0
-jump 10 greaterThanEq i:1:9 100
+jump 9 greaterThanEq i:1:9 100
 op greaterThan &t0 i:1:9 40
 op lessThan &t1 i:1:9 60
 op land &t2 &t0 &t1
-jump 7 equal &t2 0
-jump 8 always
+jump 7 equal &t2 1
 print i:1:9
 op add i:1:9 i:1:9 1
 jump 1 always

--- a/compiler/test/out/do_while_break.mlog
+++ b/compiler/test/out/do_while_break.mlog
@@ -1,7 +1,6 @@
 set i:1:4 0
 op rand &t0 1
-jump 4 lessThanEq &t0 0.5
-jump 6 always
+jump 5 greaterThan &t0 0.5
 op add i:1:4 i:1:4 1
 jump 1 lessThan i:1:4 100
 end

--- a/compiler/test/out/labels.mlog
+++ b/compiler/test/out/labels.mlog
@@ -1,12 +1,11 @@
 set i:1:16 0
-jump 18 greaterThanEq i:1:16 3
+jump 17 greaterThanEq i:1:16 3
 set j:2:11 0
-jump 16 greaterThanEq j:2:11 3
+jump 15 greaterThanEq j:2:11 3
 op equal &t0 i:1:16 1
 op equal &t1 j:2:11 1
 op land &t2 &t0 &t1
-jump 9 equal &t2 0
-jump 16 always
+jump 15 equal &t2 1
 print "i = "
 print i:1:16
 print ", j = "
@@ -17,13 +16,11 @@ jump 3 always
 op add i:1:16 i:1:16 1
 jump 1 always
 set i:9:4 0
-jump 28 greaterThanEq i:9:4 100
+jump 25 greaterThanEq i:9:4 100
 set j:12:6 0
-jump 23 notEqual i:9:4 j:12:6
-jump 28 always
-jump 25 greaterThanEq i:9:4 j:12:6
-jump 27 always
+jump 25 equal i:9:4 j:12:6
+jump 24 lessThan i:9:4 j:12:6
 op add j:12:6 j:12:6 1
-jump 21 lessThan j:12:6 100
-jump 19 always
+jump 20 lessThan j:12:6 100
+jump 18 always
 end

--- a/compiler/test/out/while_loop_break.mlog
+++ b/compiler/test/out/while_loop_break.mlog
@@ -1,8 +1,7 @@
 set i:1:4 0
-jump 7 greaterThanEq i:1:4 100
+jump 6 greaterThanEq i:1:4 100
 op rand &t0 1
-jump 5 lessThanEq &t0 0.5
-jump 7 always
+jump 6 greaterThan &t0 0.5
 op add i:1:4 i:1:4 1
 jump 1 always
 end


### PR DESCRIPTION
This pull request adds an optimization to `if` statements that merges the `if` jump with the `continue`/`break` jump.

Demonstration:
```js
for (let i = 0; i < 100; i++) {
  // skip stuff beteween 40 and 60
  if (i > 40 && i < 60) continue;
  print(i);
}
```

```diff
set i:1:9 0
- jump 10 greaterThanEq i:1:9 100
+ jump 9 greaterThanEq i:1:9 100
op greaterThan &t0 i:1:9 40
op lessThan &t1 i:1:9 60
op land &t2 &t0 &t1
- jump 7 equal &t2 0
- jump 8 always
+ jump 7 equal &t2 1
print i:1:9
op add i:1:9 i:1:9 1
jump 1 always
end
```