### PR TITLE
Optimize `for` loops with constant test values

### DIFF
--- a/compiler/src/handlers/ForStatement.ts
+++ b/compiler/src/handlers/ForStatement.ts
@@ -49,7 +49,7 @@ export const ForStatement: THandler<null> = (
       beforeEndLine,
       ...updateLines,
       new JumpInstruction(startLoopAddr, EJumpKind.Always),
-      endLoopLine,
+      ...(isInfiniteLoop ? [] : [endLoopLine]),
     ],
   ];
 };

--- a/compiler/src/handlers/ForStatement.ts
+++ b/compiler/src/handlers/ForStatement.ts
@@ -33,13 +33,18 @@ export const ForStatement: THandler<null> = (
     beforeEndLine.bindContinue(parentScope);
   }
 
+  if (test instanceof LiteralValue && !test.data) {
+    return [null, [...initInst]];
+  }
+  const isInfiniteLoop = test instanceof LiteralValue;
+
   return [
     null,
     [
       ...initInst,
       startLoopLine,
       ...testLines,
-      ...JumpInstruction.or(test, testOut),
+      ...(isInfiniteLoop ? [] : JumpInstruction.or(test, testOut)),
       ...withAlwaysRuns(c.handle(scope, node.body), false)[1],
       beforeEndLine,
       ...updateLines,

--- a/compiler/test/out/for_loop_inf.mlog
+++ b/compiler/test/out/for_loop_inf.mlog
@@ -1,5 +1,4 @@
 set i:1:9 0
-jump 5 equal 1 0
 print i:1:9
 op add i:1:9 i:1:9 1
 jump 1 always

--- a/compiler/test/out/for_loop_inf.mlog
+++ b/compiler/test/out/for_loop_inf.mlog
@@ -2,4 +2,3 @@ set i:1:9 0
 print i:1:9
 op add i:1:9 i:1:9 1
 jump 1 always
-end


### PR DESCRIPTION
Optimizes the code emitted by `for` loops with test conditions that can be resolved at compile time.
Example:
```js
for(let i = 0; ; i++) {
  print`${i}\n`
}
```
```diff
set i:1:9 0
- jump 6 equal 1 0
print i:1:9
print "\n"
op add i:1:9 i:1:9 1
jump 1 always
- end

```