### PR TITLE
Optimize empty while loops

### DIFF
--- a/compiler/test/in/empty_while_loop.js
+++ b/compiler/test/in/empty_while_loop.js
@@ -1,0 +1,20 @@
+const turret = getBuilding("scatter1");
+const radius = 5;
+const { thisx: x, thisy: y } = Vars;
+
+const unit = radar({
+  building: turret,
+  filters: ["player", "any", "any"],
+  order: true,
+  sort: "distance",
+});
+
+if (Math.len(unit.x - x, unit.y - y) > radius) {
+  print("waiting...");
+  printFlush();
+}
+
+while (Math.len(unit.x - x, unit.y - y) > radius);
+
+print("the player is near the processor");
+printFlush();

--- a/compiler/test/out/empty_while_loop.mlog
+++ b/compiler/test/out/empty_while_loop.mlog
@@ -1,0 +1,17 @@
+radar player any any distance scatter1 1 unit:5:6
+sensor &t0 unit:5:6 @x
+op sub &t1 &t0 @thisx
+sensor &t2 unit:5:6 @y
+op sub &t3 &t2 @thisy
+op len &t4 &t1 &t3
+jump 9 lessThanEq &t4 5
+print "waiting..."
+printflush message1
+sensor &t5 unit:5:6 @x
+op sub &t6 &t5 @thisx
+sensor &t7 unit:5:6 @y
+op sub &t8 &t7 @thisy
+op len &t9 &t6 &t8
+jump 9 greaterThan &t9 5
+print "the player is near the processor"
+printflush message1


### PR DESCRIPTION
Optimizes the code generated for `while` statements with empty bodies.

```js
while (Math.rand(10) < 8);
print("20% chance achieved")
printFlush()
```
```diff
op rand &t0 10
- jump 3 greaterThanEq &t0 8
- jump 0 always
+ jump 0 lessThan &t0 8
print "20% chance achieved"
printflush message1

```