### PR TITLE
Fix the `??` operator temp value creation.

### DIFF
--- a/compiler/CHANGELOG.md
+++ b/compiler/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Store values are now senseable.
 
+### Fixed
+
+- Fixed the `??` operator generating more temporary values than necessary.
+
 ## [0.5.2] - 2023-03-05
 
 ### Deprecated

--- a/compiler/src/values/StoreValue.ts
+++ b/compiler/src/values/StoreValue.ts
@@ -17,20 +17,31 @@ import { camelToDashCase, itemNames } from "../utils";
  * Stores are mutable by default.
  */
 export class StoreValue extends BaseValue implements IValue {
-  constructor(public name: string, public mutability = EMutability.mutable) {
+  temporary: boolean;
+  constructor(
+    public name: string,
+    public mutability = EMutability.mutable,
+    { temporary = false }: Partial<Pick<StoreValue, "temporary">> = {}
+  ) {
     super();
+    this.temporary = temporary;
   }
 
   static from(scope: IScope, out?: TEOutput, mutability = EMutability.mutable) {
     if (out instanceof StoreValue) return out;
-    const name = typeof out === "string" ? out : scope.makeTempName();
+    const hasName = typeof out === "string";
+    const name = hasName ? out : scope.makeTempName();
 
-    return new StoreValue(name, mutability);
+    return new StoreValue(name, mutability, {
+      temporary: !hasName,
+    });
   }
 
   static out(scope: IScope, out?: TEOutput, mutability = EMutability.mutable) {
     if (!out || typeof out === "string") {
-      return new StoreValue(out ?? scope.makeTempName(), mutability);
+      return new StoreValue(out ?? scope.makeTempName(), mutability, {
+        temporary: !out,
+      });
     }
     return out;
   }

--- a/compiler/test/in/expressions.js
+++ b/compiler/test/in/expressions.js
@@ -25,3 +25,7 @@ item ??= Items.copper;
 
 print(~Math.rand(2 ** 16));
 print(item !== Items.copper);
+
+// make sure that the ?? operator doesn't generate
+// more temp values than necessary
+print(Vars.unit.ammo ?? Vars.unit.ammoCapacity);

--- a/compiler/test/out/expressions.mlog
+++ b/compiler/test/out/expressions.mlog
@@ -38,3 +38,8 @@ print &t7
 op strictEqual &t8 item:22:4 @copper
 op equal &t9 &t8 0
 print &t9
+sensor &t10 @unit @ammo
+op strictEqual &t11 &t10 null
+jump 44 equal &t11 0
+sensor &t10 @unit @ammoCapacity
+print &t10


### PR DESCRIPTION
Fixes the `??` operator creating more temporary values than necessary.

```js
print(Vars.unit.ammo ?? Vars.unit.ammoCapacity);
```
```diff
sensor &t0 @unit @ammo
- set &t1 &t0
- op strictEqual &t2 &t0 null
- jump 5 equal &t2 0
- sensor &t1 @unit @ammoCapacity
- print &t1
+ op strictEqual &t1 &t0 null
+ jump 4 equal &t1 0
+ sensor &t0 @unit @ammoCapacity
+ print &t0
```
