### PR TITLE
Setprop support

### DIFF
--- a/compiler/CHANGELOG.md
+++ b/compiler/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added the `setProp` command (`setprop` instruction).
+
 ### Changed
 
 - Store values are now senseable.

--- a/compiler/lib/commands.d.ts
+++ b/compiler/lib/commands.d.ts
@@ -2,6 +2,7 @@ import "./kind";
 import {
   TRadarFilter,
   TRadarSort,
+  TSetPropSymbol,
   TUnitEffect,
   TUnitLocateBuildingGroup,
 } from "./util";
@@ -1255,4 +1256,10 @@ declare global {
 
   /** Sets a global flag. World processor ONLY. */
   function setFlag(flag: string, value: boolean): void;
+
+  /** Sets a property of a building or unit. World processor ONLY.*/
+  function setProp<
+    Target extends BasicUnit | BasicBuilding,
+    K extends TSetPropSymbol & keyof Target
+  >(property: K, target: Target, value: Target[K]): void;
 }

--- a/compiler/lib/util.d.ts
+++ b/compiler/lib/util.d.ts
@@ -46,3 +46,15 @@ export type TUnitEffect =
   | "boss"
   | "shocked"
   | "blasted";
+
+export type TSetPropSymbol =
+  | ItemSymbol
+  | LiquidSymbol
+  | (typeof LAccess)[
+      | "x"
+      | "y"
+      | "rotation"
+      | "team"
+      | "health"
+      | "totalPower"
+      | "payloadType"];

--- a/compiler/src/initScope.ts
+++ b/compiler/src/initScope.ts
@@ -75,4 +75,5 @@ export function initScope(scope: Scope) {
   scope.hardSet("fetch", new commands.Fetch());
   scope.hardSet("getFlag", new commands.GetFlag());
   scope.hardSet("setFlag", new commands.SetFlag());
+  scope.hardSet("setProp", new commands.SetProp());
 }

--- a/compiler/src/macros/commands/SetProp.ts
+++ b/compiler/src/macros/commands/SetProp.ts
@@ -1,0 +1,15 @@
+import { CompilerError } from "../../CompilerError";
+import { InstructionBase } from "../../instructions";
+import { MacroFunction } from "../Function";
+
+export class SetProp extends MacroFunction<null> {
+  constructor() {
+    super((scope, out, property, target, value) => {
+      if (!property) throw new CompilerError("Missing argument: property");
+      if (!target) throw new CompilerError("Missing argument: target");
+      if (!value) throw new CompilerError("Missing argument: value");
+
+      return [null, [new InstructionBase("setprop", property, target, value)]];
+    });
+  }
+}

--- a/compiler/src/macros/commands/index.ts
+++ b/compiler/src/macros/commands/index.ts
@@ -28,3 +28,4 @@ export * from "./SetRate";
 export * from "./Fetch";
 export * from "./GetFlag";
 export * from "./SetFlag";
+export * from "./SetProp";

--- a/website/docs/guide/commands.md
+++ b/website/docs/guide/commands.md
@@ -1402,3 +1402,12 @@ Sets a global flag.
 ```js
 setFlag("foo", true);
 ```
+
+### `setProp`
+
+Sets a property of a building or unit.
+
+```js
+const router = fetch.build(Teams.sharded, 0, Blocks.router);
+setProp(LAccess.team, router, Teams.derelict);
+```

--- a/website/src/mlog/lang.ts
+++ b/website/src/mlog/lang.ts
@@ -40,6 +40,7 @@ export function registerMlogLang(monaco: Monaco) {
       "fetch",
       "getflag",
       "setflag",
+      "setprop",
     ],
     flowInst: ["jump", "end", "wait", "stop"],
     operator: [


### PR DESCRIPTION
Adds support for the `setprop` instruction.

```js
const router = fetch.build(Teams.sharded, 0, Blocks.router);
setProp(LAccess.team, router, Teams.derelict);
```