### PR TITLE
Drop support for `unitControl.pathfind`

### DIFF
--- a/compiler/CHANGELOG.md
+++ b/compiler/CHANGELOG.md
@@ -17,13 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Synchronized the block symbol table with the game's.
 - Store values are now senseable.
 
-### Fixed
-
-- Fixed the `??` operator generating more temporary values than necessary.
-
 ### Removed
 
 - Removed support for the `unitControl.pathfind` command.
+
+### Fixed
+
+- Fixed the `??` operator generating more temporary values than necessary.
 
 ## [0.5.2] - 2023-03-05
 
@@ -100,7 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added operation caching for arithmethic operators and Math functions.
 
-### FIxed
+### Fixed
 
 - Fixed empty `if` statements having their jumps unduly removed.
 

--- a/compiler/CHANGELOG.md
+++ b/compiler/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed the `??` operator generating more temporary values than necessary.
 
+### Removed
+
+- Removed support for the `unitControl.pathfind` command.
+
 ## [0.5.2] - 2023-03-05
 
 ### Deprecated

--- a/compiler/lib/commands.d.ts
+++ b/compiler/lib/commands.d.ts
@@ -561,13 +561,6 @@ declare global {
     function boost(enable: boolean): void;
 
     /**
-     * Makes the unit bound to this processor move to the enemy spawn
-     *
-     * @deprecated This command is no longer available in mindustry v7.
-     */
-    function pathfind(): void;
-
-    /**
      * Makes the unit bound to this processor shoot/aim at the given position
      * @param options.shoot `true` to shoot, `false` to just aim
      */

--- a/compiler/src/macros/commands/UnitControl.ts
+++ b/compiler/src/macros/commands/UnitControl.ts
@@ -13,7 +13,6 @@ export class UnitControl extends ObjectValue {
         move: { args: ["x", "y"] },
         approach: { named: "options", args: ["x", "y", "radius"] },
         boost: { args: ["enable"] },
-        pathfind: { args: [] },
         target: { named: "options", args: ["x", "y", "shoot"] },
         targetp: { named: "options", args: ["unit", "shoot"] },
         itemDrop: { args: ["target", "amount"] },


### PR DESCRIPTION
The command no longer exists in Mindustry and was deprecated in the previous mlogjs version.