### PR TITLE
Fix the switch falltrough detection

### DIFF
--- a/compiler/CHANGELOG.md
+++ b/compiler/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed the fallthrough detection of `case`s in a `switch`.
 - Fixed the `??` operator generating more temporary values than necessary.
 
 ## [0.5.2] - 2023-03-05

--- a/compiler/src/handlers/SwitchStatement.ts
+++ b/compiler/src/handlers/SwitchStatement.ts
@@ -1,10 +1,4 @@
-import {
-  AddressResolver,
-  BreakInstruction,
-  EJumpKind,
-  JumpInstruction,
-  SetCounterInstruction,
-} from "../instructions";
+import { AddressResolver, EJumpKind, JumpInstruction } from "../instructions";
 import {
   EInstIntent,
   EMutability,
@@ -44,7 +38,7 @@ export const SwitchStatement: THandler<null> = (
     const bodyAdress = new LiteralValue(null);
     const bodyLine = new AddressResolver(bodyAdress);
 
-    const canFallInto = !endsWithoutFalltrough(inst, endLine);
+    const canFallInto = !endsWithoutFalltrough(inst);
     let includeJump = !constantCase;
     const includeBody = !constantCase || canFallInto;
 
@@ -82,7 +76,7 @@ export const SwitchStatement: THandler<null> = (
         if (
           noFallInto &&
           onlyConstantTests &&
-          (isLastCase || endsWithoutFalltrough(bodyInst(), endLine))
+          (isLastCase || endsWithoutFalltrough(bodyInst()))
         ) {
           return [null, [...bodyInst(), endLine]];
         }
@@ -125,7 +119,7 @@ export const SwitchStatement: THandler<null> = (
   ];
 };
 
-function endsWithoutFalltrough(inst: IInstruction[], endLine: AddressResolver) {
+function endsWithoutFalltrough(inst: IInstruction[]) {
   if (inst.length === 0) return true;
   for (let i = inst.length - 1; i >= 0; i--) {
     const instruction = inst[i];
@@ -139,12 +133,7 @@ function endsWithoutFalltrough(inst: IInstruction[], endLine: AddressResolver) {
     if (instruction instanceof AddressResolver) return false;
     if (instruction.hidden) continue;
 
-    return (
-      instruction instanceof SetCounterInstruction ||
-      instruction.intent === EInstIntent.return ||
-      (instruction instanceof BreakInstruction &&
-        endLine.bonds.includes(instruction.address))
-    );
+    return instruction.intent !== EInstIntent.none;
   }
   return false;
 }

--- a/compiler/test/in/switch_optimization.js
+++ b/compiler/test/in/switch_optimization.js
@@ -56,3 +56,18 @@ switch (a) {
   default:
     print("default");
 }
+
+// test falltrough detection with other stuff
+
+switch (a) {
+  case 0:
+    print("first");
+    endScript();
+  case 1:
+    print("second");
+    stopScript();
+  case 3:
+    print("third");
+  default:
+    print("default");
+}

--- a/compiler/test/out/switch_optimization.mlog
+++ b/compiler/test/out/switch_optimization.mlog
@@ -13,4 +13,6 @@ jump 14 always
 print "dynamic b"
 jump 15 always
 print "one"
+print "second"
+stop
 end


### PR DESCRIPTION
Previously it only worked with break statements that targetted the end of the switch's body and return statements. Now it also takes in account other forms of control flow disruption, such as the end and stop instructions, and continue statements.