### PR TITLE
More apply status effects

### DIFF
--- a/compiler/CHANGELOG.md
+++ b/compiler/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Expanded the list of supported status effects for the `applyStatus` command.
 - Logical operators are now able to short-circuit.
 - Synchronized the block symbol table with the game's.
 - Store values are now senseable.

--- a/compiler/lib/commands.d.ts
+++ b/compiler/lib/commands.d.ts
@@ -4,8 +4,9 @@ import {
   TSettablePropSymbol,
   TRadarFilter,
   TRadarSort,
-  TUnitEffect,
   TUnitLocateBuildingGroup,
+  TStatusEffect,
+  TPermanentStatusEffect,
 } from "./util";
 declare global {
   /**
@@ -941,17 +942,17 @@ declare global {
      * The only status effects that don't require a duration are `overdrive` and `boss`.
      */
     function apply(
-      status: Exclude<TUnitEffect, "overdrive" | "boss">,
+      status: Exclude<TStatusEffect, TPermanentStatusEffect>,
       unit: BasicUnit,
       duration: number
     ): void;
 
-    function apply(status: "overdrive" | "boss", unit: BasicUnit): void;
+    function apply(status: TPermanentStatusEffect, unit: BasicUnit): void;
 
     /**
      * Removes a status effect to the given unit.
      */
-    function clear(status: TUnitEffect, unit: BasicUnit): void;
+    function clear(status: TStatusEffect, unit: BasicUnit): void;
   }
 
   /**

--- a/compiler/lib/util.d.ts
+++ b/compiler/lib/util.d.ts
@@ -34,21 +34,28 @@ export type TUnitLocateBuildingGroup =
   | "battery"
   | "reactor";
 
-export type TUnitEffect =
+export type TStatusEffect =
   | "burning"
   | "freezing"
   | "unmoving"
+  | "slow"
   | "wet"
+  | "muddy"
   | "melting"
   | "sapped"
-  | "electrified"
-  | "spore-slowed"
   | "tarred"
-  | "overdrive"
   | "overclock"
-  | "boss"
+  | "shielded"
   | "shocked"
-  | "blasted";
+  | "blasted"
+  | "corroded"
+  | "spore-slowed"
+  | "disarmed"
+  | "electrified"
+  | "invincible"
+  | TPermanentStatusEffect;
+
+export type TPermanentStatusEffect = "boss" | "overdrive";
 
 type CommonSettableProps = {
   [P in keyof typeof Items | keyof typeof Liquids]: number;

--- a/compiler/src/macros/commands/ApplyStatus.ts
+++ b/compiler/src/macros/commands/ApplyStatus.ts
@@ -5,20 +5,27 @@ import { LiteralValue, ObjectValue } from "../../values";
 import { createOverloadNamespace } from "../util";
 
 const validEffects = [
+  "none",
   "burning",
   "freezing",
   "unmoving",
+  "slow",
   "wet",
+  "muddy",
   "melting",
   "sapped",
-  "electrified",
-  "spore-slowed",
   "tarred",
   "overdrive",
   "overclock",
-  "boss",
+  "shielded",
   "shocked",
   "blasted",
+  "corroded",
+  "boss",
+  "spore-slowed",
+  "disarmed",
+  "electrified",
+  "invincible",
 ] as const;
 
 export class ApplyStatus extends ObjectValue {


### PR DESCRIPTION
Adds support for more status effects to the `applyStatus` command, given that they work on the game and are just not accessible through the UI.

Status effects such as `corroded` and `invincible` are now accepted by the compiler.
