### PR TITLE
Fix mlog highlighting for @variables

### DIFF
--- a/website/docs/.vitepress/langs/mlog.tmLanguage.json
+++ b/website/docs/.vitepress/langs/mlog.tmLanguage.json
@@ -11,7 +11,7 @@
       "name": "keyword"
     },
     {
-      "match": "@[a-zA-Z-_]+",
+      "match": "@[a-zA-Z-_0-9]+",
       "name": "variable"
     },
     {

--- a/website/src/mlog/lang.ts
+++ b/website/src/mlog/lang.ts
@@ -99,7 +99,7 @@ export function registerMlogLang(monaco: Monaco) {
             },
           },
         ],
-        [/\@[a-zA-Z-_]+/, "variable"],
+        [/\@[a-zA-Z-_0-9]+/, "variable"],
         [/(\w+:)?\d+:\d+/, "key.parameter"],
         [/&[a-zA-Z0-9:]+/, "variable.predefined"],
         [/\b[\-+]?\d+\.\d+\b/, "number.float"],


### PR DESCRIPTION
Fixes the highlighting for built-in variables that contain numbers, such as `@build1`.