### PR TITLE
Add support the `unitControl.pathfind` 2.0 command

### DIFF
--- a/compiler/CHANGELOG.md
+++ b/compiler/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added support for the new version of `ucontrol pathfind` (`unitControl.pathfind`).
 - Added the `setProp` command (`setprop` instruction).
 
 ### Changed

--- a/compiler/lib/commands.d.ts
+++ b/compiler/lib/commands.d.ts
@@ -541,7 +541,13 @@ declare global {
     function stop(): void;
 
     /**
-     * Makes the unit bound to this processor move to the given position
+     * Makes the unit bound to this processor move to the given position.
+     *
+     * The unit tends to move in a straight line to the target location,
+     * which doesn't work in situations where the unit encounters an obstacle
+     * (such as a dagger trying to get past a wall).
+     *
+     * For those scenarios it's better to use `unitControl.pathfind`.
      */
     function move(x: number, y: number): void;
 
@@ -555,6 +561,14 @@ declare global {
       /** How distant to the position the unit can be */
       radius: number;
     }): void;
+
+    /**
+     * Makes the unit bound to this processor move to the given location.
+     *
+     * Uses the unit's pathfinding algorithm to decide how to
+     * reach the desired location instead of blidly going in a straight line.
+     */
+    function pathfind(x: number, y: number): void;
 
     /**
      * Whether the unit bound to this processor should be boosted (floating)

--- a/compiler/src/macros/commands/UnitControl.ts
+++ b/compiler/src/macros/commands/UnitControl.ts
@@ -12,6 +12,7 @@ export class UnitControl extends ObjectValue {
         stop: { args: [] },
         move: { args: ["x", "y"] },
         approach: { named: "options", args: ["x", "y", "radius"] },
+        pathfind: { args: ["x", "y"] },
         boost: { args: ["enable"] },
         target: { named: "options", args: ["x", "y", "shoot"] },
         targetp: { named: "options", args: ["unit", "shoot"] },

--- a/compiler/test/in/unit_commands.js
+++ b/compiler/test/in/unit_commands.js
@@ -1,5 +1,6 @@
 unitBind(Units.flare);
 unitControl.approach({ x: 0, y: 0, radius: 5 });
+unitControl.pathfind(0, 0);
 unitControl.boost(true);
 unitControl.build({ x: 0, y: 0, block: Blocks.router, rotation: 0 });
 unitControl.flag(123);

--- a/compiler/test/out/unit_commands.mlog
+++ b/compiler/test/out/unit_commands.mlog
@@ -1,5 +1,6 @@
 ubind @flare
 ucontrol approach 0 0 5
+ucontrol pathfind 0 0
 ucontrol boost 1
 ucontrol build 0 0 @router 0
 ucontrol flag 123
@@ -8,13 +9,13 @@ ucontrol idle
 ucontrol itemDrop @air 100
 ucontrol itemTake shard1 @copper 10
 ucontrol unbind
-ucontrol within 1 2 10 isWithin:13:6 0
-print isWithin:13:6
-ucontrol getBlock 10 20 type:16:7 building:16:13 floor:16:23
-print type:16:7
-print building:16:13
-print floor:16:23
-ulocate building core 0 @copper coreX:20:16 coreY:20:23 coreFound:20:5 core:20:30
-ulocate ore core true @lead oreX:24:15 oreY:24:21 oreFound:24:5 &_
-ulocate damaged core true @copper dX:25:13 dY:25:17 dFound:25:5 dBuilding:25:21
-ulocate spawn core true @copper sX:26:13 sY:26:17 sFound:26:5 sBuilding:26:21
+ucontrol within 1 2 10 isWithin:14:6 0
+print isWithin:14:6
+ucontrol getBlock 10 20 type:17:7 building:17:13 floor:17:23
+print type:17:7
+print building:17:13
+print floor:17:23
+ulocate building core 0 @copper coreX:21:16 coreY:21:23 coreFound:21:5 core:21:30
+ulocate ore core true @lead oreX:25:15 oreY:25:21 oreFound:25:5 &_
+ulocate damaged core true @copper dX:26:13 dY:26:17 dFound:26:5 dBuilding:26:21
+ulocate spawn core true @copper sX:27:13 sY:27:17 sFound:27:5 sBuilding:27:21

--- a/website/docs/guide/commands.md
+++ b/website/docs/guide/commands.md
@@ -525,6 +525,29 @@ Controls the unit bound to the processor
   });
   ```
 
+- #### `untiControl.pathfind`
+
+  Makes the unit bound to this processor move to the given location.
+
+  Uses the unit's pathfinding algorithm to decide how to
+  reach the desired location instead of blidly going in a straight line.
+
+  ```js
+  // makes flares follow the player's cursor
+  const turret = getBuilding("foreshadow1");
+
+  const player = radar({
+    building: turret,
+    filters: ["player", "any", "any"],
+    order: true,
+    sort: "distance",
+  });
+
+  unitBind(Units.flare);
+
+  unitControl.pathfind(player.shootX, player.shootY);
+  ```
+
 - #### `unitControl.boost`
 
   Whether the unit bound to this processor should be boosted (floating).


### PR DESCRIPTION
Mindustry [build 144](https://github.com/Anuken/Mindustry/releases/tag/v144) reintroduced the `ucontrol pathfind` instruction, that can now receive custom coordinates.
This pull request re-adds support for the instruction.