### PR TITLE
Explicit to mlog string method

### DIFF
--- a/compiler/CHANGELOG.md
+++ b/compiler/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed escaping of double quotes in string literals.
+- Fixed escaping of backslashes in string literals.
 - Fixed `break` statements not working inside infinite `for` loops.
 - Fixed the fallthrough detection of `case`s in a `switch`.
 - Fixed the `??` operator generating more temporary values than necessary.

--- a/compiler/src/handlers/VariableDeclaration.ts
+++ b/compiler/src/handlers/VariableDeclaration.ts
@@ -310,7 +310,7 @@ class DeclarationValue extends VoidValue {
     return "DeclarationValue";
   }
 
-  toString() {
+  toMlogString() {
     return '"[macro DeclarationValue]"';
   }
 }

--- a/compiler/src/instructions/InstructionBase.ts
+++ b/compiler/src/instructions/InstructionBase.ts
@@ -1,5 +1,6 @@
 import { SourceLocation } from "@babel/types";
 import { EInstIntent, IInstruction, IValue } from "../types";
+import { formatInstructionArgs } from "../utils";
 
 export class InstructionBase implements IInstruction {
   intent = EInstIntent.none;
@@ -22,6 +23,6 @@ export class InstructionBase implements IInstruction {
   }
   resolve(_i: number) {}
   toString() {
-    return this.args.filter(arg => arg).join(" ");
+    return formatInstructionArgs(this.args).join(" ");
   }
 }

--- a/compiler/src/instructions/ZeroSpaceInstruction.ts
+++ b/compiler/src/instructions/ZeroSpaceInstruction.ts
@@ -1,7 +1,8 @@
+import { formatInstructionArgs } from "../utils";
 import { InstructionBase } from "./InstructionBase";
 
 export class ZeroSpaceInstruction extends InstructionBase {
   toString() {
-    return this.args.join("");
+    return formatInstructionArgs(this.args).join("");
   }
 }

--- a/compiler/src/macros/DynamicArray.ts
+++ b/compiler/src/macros/DynamicArray.ts
@@ -371,7 +371,7 @@ export class DynamicArray extends ObjectValue {
     return `${id}("${this.name}")`;
   }
 
-  toString() {
+  toMlogString() {
     const id = this.dynamic ? "DynamicArray" : "MutableArray";
     return `"[macro ${id}]"`;
   }
@@ -574,7 +574,7 @@ class DynamicArrayEntry extends BaseValue {
     return `${name}Entry`;
   }
 
-  toString() {
+  toMlogString() {
     const name = this.array.dynamic ? "DynamicArray" : "MutableArray";
     return `"[macro ${name}Entry]"`;
   }

--- a/compiler/src/macros/Function.ts
+++ b/compiler/src/macros/Function.ts
@@ -41,7 +41,7 @@ export class MacroFunction<
     return "MacroFunction";
   }
 
-  toString(): string {
+  toMlogString(): string {
     return '"[macro MacroFunction]"';
   }
 }

--- a/compiler/src/macros/Memory.ts
+++ b/compiler/src/macros/Memory.ts
@@ -47,7 +47,7 @@ class MemoryEntry extends BaseValue {
     return "MemoryEntry";
   }
 
-  toString(): string {
+  toMlogString(): string {
     return '"[macro MemoryEntry]"';
   }
 }
@@ -84,10 +84,10 @@ class MemoryMacro extends ObjectValue {
   }
 
   debugString(): string {
-    return `Memory("${this.cell.toString()}")`;
+    return `Memory("${this.cell.toMlogString()}")`;
   }
 
-  toString() {
+  toMlogString() {
     return '"[macro Memory]"';
   }
 }

--- a/compiler/src/types.ts
+++ b/compiler/src/types.ts
@@ -303,6 +303,9 @@ export interface IValue extends IValueOperators {
   /** The string representation of `this` in error messages. */
   debugString(): string;
 
+  /** The string representation of `this` in the generated mlog code. */
+  toMlogString(): string;
+
   /**
    * Allows some values to choose alternative representations
    * when they are used as operation outputs.

--- a/compiler/src/utils/instruction.ts
+++ b/compiler/src/utils/instruction.ts
@@ -72,3 +72,11 @@ export function usesAddressResolver(
   }
   return false;
 }
+
+export function formatInstructionArgs(
+  args: (IValue | string | null)[]
+): string[] {
+  return args
+    .filter((value): value is IValue | string => !!value)
+    .map(value => (typeof value === "string" ? value : value.toMlogString()));
+}

--- a/compiler/src/values/AssignmentValue.ts
+++ b/compiler/src/values/AssignmentValue.ts
@@ -33,7 +33,7 @@ export class AssignmentValue extends VoidValue {
     return "AssignmentValue";
   }
 
-  toString(): string {
+  toMlogString(): string {
     return '"[macro AssignmentValue]"';
   }
 }

--- a/compiler/src/values/DestructuringValue.ts
+++ b/compiler/src/values/DestructuringValue.ts
@@ -71,7 +71,7 @@ export class DestructuringValue extends VoidValue {
     return "DestructuringValue";
   }
 
-  toString(): string {
+  toMlogString(): string {
     return '"[macro DestructuringValue]"';
   }
 }

--- a/compiler/src/values/FunctionValue.ts
+++ b/compiler/src/values/FunctionValue.ts
@@ -293,7 +293,7 @@ export class FunctionValue extends VoidValue implements IFunctionValue {
     return `FunctionValue("${this.name}")`;
   }
 
-  toString() {
+  toMlogString() {
     return '"[macro FunctionValue]"';
   }
 

--- a/compiler/src/values/JumpOutValue.ts
+++ b/compiler/src/values/JumpOutValue.ts
@@ -81,7 +81,7 @@ export class JumpOutValue extends VoidValue {
     return "JumpOutValue";
   }
 
-  toString(): string {
+  toMlogString(): string {
     return '"[macro JumpOutValue]"';
   }
 }

--- a/compiler/src/values/LazyValue.ts
+++ b/compiler/src/values/LazyValue.ts
@@ -15,7 +15,7 @@ export class LazyValue extends VoidValue {
     return "LazyValue";
   }
 
-  toString(): string {
+  toMlogString(): string {
     return '"[macro LazyValue]"';
   }
 }

--- a/compiler/src/values/LiteralValue.ts
+++ b/compiler/src/values/LiteralValue.ts
@@ -34,12 +34,12 @@ export class LiteralValue<T extends TLiteral | null = TLiteral>
   constructor(data: T) {
     super();
     this.data = data;
-    this.name = this.toString();
+    this.name = this.toMlogString();
   }
   eval(_scope: IScope): TValueInstructions {
     return [this, []];
   }
-  toString() {
+  toMlogString() {
     return JSON.stringify(this.data);
   }
   get(scope: IScope, name: IValue): TValueInstructions {
@@ -83,7 +83,7 @@ export class LiteralValue<T extends TLiteral | null = TLiteral>
   }
 
   debugString(): string {
-    return this.toString();
+    return this.toMlogString();
   }
 }
 

--- a/compiler/src/values/LiteralValue.ts
+++ b/compiler/src/values/LiteralValue.ts
@@ -34,13 +34,22 @@ export class LiteralValue<T extends TLiteral | null = TLiteral>
   constructor(data: T) {
     super();
     this.data = data;
-    this.name = this.toMlogString();
+    this.name = JSON.stringify(this.data);
   }
   eval(_scope: IScope): TValueInstructions {
     return [this, []];
   }
   toMlogString() {
-    return JSON.stringify(this.data);
+    const { data } = this;
+    if (typeof data !== "string") return JSON.stringify(data);
+
+    // this special handling is required because of
+    // how mindustry parses string literals in logic statements
+
+    // replace double quotes by two single quotes before
+    // forming the json string
+    // (there is no way to escape a " character)
+    return JSON.stringify(data.replace(/"/g, "''")).replace(/\\\\/g, "\\"); // "unescape" backslashes
   }
   get(scope: IScope, name: IValue): TValueInstructions {
     if (!(name instanceof LiteralValue && name.isString()))

--- a/compiler/src/values/ObjectValue.ts
+++ b/compiler/src/values/ObjectValue.ts
@@ -107,7 +107,7 @@ export class ObjectValue extends VoidValue {
     return "ObjectValue";
   }
 
-  toString(): string {
+  toMlogString(): string {
     return '"[macro ObjectValue]"';
   }
 }

--- a/compiler/src/values/StoreValue.ts
+++ b/compiler/src/values/StoreValue.ts
@@ -129,7 +129,7 @@ export class StoreValue extends BaseValue implements IValue {
     return `StoreValue("${this.name}")`;
   }
 
-  toString() {
+  toMlogString() {
     return this.name;
   }
 }

--- a/compiler/src/values/VoidValue.ts
+++ b/compiler/src/values/VoidValue.ts
@@ -50,7 +50,7 @@ export class VoidValue implements IValue {
     return "VoidValue";
   }
 
-  toString(): string {
+  toMlogString(): string {
     return '"[macro VoidValue]"';
   }
 }

--- a/compiler/test/in/string_literal_formatting.js
+++ b/compiler/test/in/string_literal_formatting.js
@@ -1,0 +1,1 @@
+print('a special string with " and \\');

--- a/compiler/test/out/string_literal_formatting.mlog
+++ b/compiler/test/out/string_literal_formatting.mlog
@@ -1,0 +1,1 @@
+print "a special string with '' and \"


### PR DESCRIPTION
Adds the `toMlogString` method to the `IValue` interface. This change was made to remove the overriding of the `toString` method present in all objects, which could cause problems during implicit string conversions.

Fixes #177.
Fixes #178.