### PR TITLE
Fix `toString` calls in literals

### DIFF
--- a/compiler/src/values/LiteralValue.ts
+++ b/compiler/src/values/LiteralValue.ts
@@ -55,7 +55,10 @@ export class LiteralValue<T extends TLiteral | null = TLiteral>
     if (!(name instanceof LiteralValue && name.isString()))
       return super.get(scope, name);
     const method = literalMethods[name.data];
-    if (!method)
+    if (
+      !method ||
+      !Object.prototype.hasOwnProperty.call(literalMethods, name.data)
+    )
       throw new CompilerError(
         `The member [${name.debugString()}] does not exist on literal values.`
       );

--- a/compiler/test/fail/to_string_in_literals.js
+++ b/compiler/test/fail/to_string_in_literals.js
@@ -1,0 +1,2 @@
+// The member ["toString"] does not exist on literal values.
+(1).toString();


### PR DESCRIPTION
Comparing the errors generated before and after this pull request:
```js
(0).toString()

```
Before: 

`i.eval is not a function or its return value is not iterable`

After: 
`The member ["toString"] does not exist on literal values.`
