### PR TITLE
Mention angle diff in the syntax docs

### DIFF
--- a/website/docs/guide/syntax-support.md
+++ b/website/docs/guide/syntax-support.md
@@ -266,6 +266,7 @@ available on the mlog runtime. They are listed bellow:
 - `radToDeg` - The convertion ratio for radians to degrees.
 - `abs` - Absolute value of a number
 - `angle` - Angle of a vector in degrees
+- `angleDiff` - Absolute distance between two angles in degrees.
 - `acos` - The arc cosine of a number, in degrees.
 - `asin` - The arc sine of a number, in degrees.
 - `atan` - The arc tangent of a number, in degrees.


### PR DESCRIPTION
Adds `Math.angleDiff` to the list of mathematical functions in the documentation.