### PR TITLE
Fix discord links

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Changes for each release are documented in the [CHANGELOG](https://github.com/ml
 
 ## Contribute
 
-Having trouble? [Ask for help on discord](https://discord.gg/2VudfNUp)
+Having trouble? [Ask for help on discord](https://discord.gg/SvgjCtZnR5)
 or [open an issue](https://github.com/mlogjs/mlogjs/issues/new)
 
 Help and suggestions are welcomed!
@@ -69,4 +69,4 @@ MIT
 [ci]: https://github.com/mlogjs/mlogjs/actions/workflows/ci.yml
 [docs]: https://mlogjs.github.io/mlogjs/
 [unreleased docs]: https://mlogjs.netlify.app
-[discord]: https://discord.gg/SvgjCtZnR5
+[discord]: https://discord.gg/98KWSSUPVj

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -54,7 +54,7 @@ Changes for each release are documented in the [CHANGELOG](https://github.com/ml
 
 ## Contribute
 
-Having trouble? [Ask for help on discord](https://discord.gg/2VudfNUp)
+Having trouble? [Ask for help on discord](https://discord.gg/SvgjCtZnR5)
 or [open an issue](https://github.com/mlogjs/mlogjs/issues/new)
 
 Help and suggestions are welcomed!
@@ -69,4 +69,4 @@ MIT
 [ci]: https://github.com/mlogjs/mlogjs/actions/workflows/ci.yml
 [docs]: https://mlogjs.github.io/mlogjs/
 [unreleased docs]: https://mlogjs.netlify.app
-[discord]: https://discord.gg/SvgjCtZnR5
+[discord]: https://discord.gg/98KWSSUPVj

--- a/website/docs/.vitepress/config.ts
+++ b/website/docs/.vitepress/config.ts
@@ -34,7 +34,7 @@ const config: UserConfig = {
             text: "Changelog",
             link: "https://github.com/mlogjs/mlogjs/blob/main/compiler/CHANGELOG.md",
           },
-          { text: "Discord", link: "https://discord.gg/2VudfNUp" },
+          { text: "Discord", link: "https://discord.gg/98KWSSUPVj" },
         ],
       },
     ],
@@ -64,7 +64,7 @@ const config: UserConfig = {
 
     socialLinks: [
       { icon: "github", link: "https://github.com/mlogjs/mlogjs" },
-      { icon: "discord", link: "https://discord.gg/2VudfNUp" },
+      { icon: "discord", link: "https://discord.gg/98KWSSUPVj" },
     ],
   },
   markdown: {


### PR DESCRIPTION
Uses fixed invite urls to the discord server. 
Previously the links used were temporary, which meant that they expired after some time.