### PR TITLE
Add support for `LAccess.id`

### DIFF
--- a/compiler/CHANGELOG.md
+++ b/compiler/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added typings for the `id` property on symbols.
 - Added the `getBuildings` helper function.
 - Added support for the `anglediff` operation (at `Math.angleDiff`).
 - Added support for the new version of `ucontrol pathfind` (`unitControl.pathfind`).

--- a/compiler/lib/commands.d.ts
+++ b/compiler/lib/commands.d.ts
@@ -491,7 +491,18 @@ declare global {
    */
   function wait(seconds: number): void;
 
-  /** Looks up content symbols by their index. */
+  /**
+   * Looks up content symbols by their index.
+   *
+   * For the inverse of this operation, you can sense the `id` of a symbol:
+   *
+   * ```js
+   * const { type } = getLink(0);
+   *
+   * print(type === lookup.block(type.id));
+   * printFlush(); // prints "1"
+   * ```
+   */
   namespace lookup {
     /**
      * Looks up a block symbol by it's index on the content registry.

--- a/compiler/lib/eslib/lib.es5.d.ts
+++ b/compiler/lib/eslib/lib.es5.d.ts
@@ -1,6 +1,17 @@
 /// <reference no-default-lib="true"/>
 
-interface Symbol {}
+interface Symbol {
+  /**
+   * The `lookup` id of this symbol.
+   *
+   * Due to typescript's limitations, this property has been
+   * declared for all symbols, even ones that shouldn't have it.
+   *
+   * If a symbol is not part of `ItemSymbol`, `LiquidSymbol`,
+   * `UnitSymbol`, or `BlockSymbol`, it likely does not have an id.
+   */
+  readonly id: number;
+}
 
 interface SymbolConstructor {}
 

--- a/compiler/lib/globals.d.ts
+++ b/compiler/lib/globals.d.ts
@@ -244,6 +244,7 @@ declare namespace LAccess {
   const name: unique symbol;
   const payloadCount: unique symbol;
   const payloadType: unique symbol;
+  const id: unique symbol;
   const enabled: unique symbol;
   const config: unique symbol;
   const color: unique symbol;

--- a/website/docs/guide/commands.md
+++ b/website/docs/guide/commands.md
@@ -258,6 +258,11 @@ const result = sensor(myCustomSymbol, container1);
 
 Looks up content symbols by their index.
 
+For the inverse of this operation, you can sense the `id` of a symbol:
+
+::: command-example
+:::
+
 - #### `lookup.block`
 
   Looks up a block symbol by it's index on the content registry.

--- a/website/docs/guide/namespaces.md
+++ b/website/docs/guide/namespaces.md
@@ -198,6 +198,7 @@ This namespace contains all symbols that can be used to access properties of ent
 - `name`
 - `payloadCount`
 - `payloadType`
+- `id`
 - `enabled`
 - `config`
 - `color`


### PR DESCRIPTION
This pull request adds the necessary type declarations and documentation to make using the [new](https://github.com/Anuken/Mindustry/releases/tag/v146) `LAccess.id` symbol.