### PR TITLE
Fix compile-time bitwise ops

### DIFF
--- a/compiler/CHANGELOG.md
+++ b/compiler/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed compile time operation evaluation not working properly on values bigger than 2^31-1.
 - Fixed the online editor parsing declaration files multiple times.
 - Fixed missing field declarations on units and buildings.
 - Fixed calling `toString` in a literal value not having the correct error message.

--- a/compiler/src/operators.ts
+++ b/compiler/src/operators.ts
@@ -108,12 +108,14 @@ export const operatorMap = {
   "&": "and",
   "^": "xor",
   ">>": "shr",
-  ">>>": "shr",
   "<<": "shl",
   "&&": "land",
   "||": "or",
 } as const satisfies Record<
-  Exclude<BinaryOperator | LogicalOperator, "instanceof" | "in" | "!==" | "??">,
+  Exclude<
+    BinaryOperator | LogicalOperator,
+    "instanceof" | "in" | "!==" | "??" | ">>>"
+  >,
   string
 >;
 

--- a/compiler/src/values/LiteralValue.ts
+++ b/compiler/src/values/LiteralValue.ts
@@ -71,7 +71,7 @@ export class LiteralValue<T extends TLiteral | null = TLiteral>
     return false;
   }
 
-  get num() {
+  get num(): number {
     if (this.data === null) return 0;
     if (typeof this.data === "string") return 1;
     return this.data;
@@ -148,7 +148,13 @@ for (const k in operatorMap) {
       return BaseValue.prototype[key].apply(this, [scope, value, out]);
     }
 
-    return [new LiteralValue(fn(this.data as never, value.data as never)), []];
+    // patch constant string concatenation
+    // TODO: remove this in favor of the `concat` function
+    if (key === "+" && this.isString()) {
+      return [new LiteralValue(this.data + value.data), []];
+    }
+
+    return [new LiteralValue(fn(this.num, value.num)), []];
   };
 }
 
@@ -167,7 +173,7 @@ for (const key in unaryOperatorMap) {
     this: LiteralValue,
   ): TValueInstructions {
     const fn = unaryOperatorMap[key as K];
-    return [new LiteralValue(fn(this.data as never)), []];
+    return [new LiteralValue(fn(this.num)), []];
   };
 }
 

--- a/compiler/src/values/LiteralValue.ts
+++ b/compiler/src/values/LiteralValue.ts
@@ -117,12 +117,11 @@ const operatorMap = {
   "&": (a, b) => a & b,
   "^": (a, b) => a ^ b,
   ">>": (a, b) => a >> b,
-  ">>>": (a, b) => a >> b,
   "<<": (a, b) => a << b,
   "&&": (a, b) => +(a && b),
   "||": (a, b) => +(a || b),
 } as const satisfies Record<
-  Exclude<BinaryOperator | LogicalOperator, "instanceof" | "in" | "??">,
+  Exclude<BinaryOperator | LogicalOperator, "instanceof" | "in" | "??" | ">>>">,
   TBinOperationFn
 >;
 

--- a/compiler/test/in/constant_bitwise.js
+++ b/compiler/test/in/constant_bitwise.js
@@ -1,0 +1,12 @@
+// makes sure that the compiler evaluates constant bitwise
+// operations using 64-bit integers to have parity with
+// the mlog runtime
+
+// integer outside the limits of 32-bit integers
+const value = 2 ** 33;
+
+print(value >> 30, "\n"); // expected: 8
+print(value | 0, "\n"); // should not lose precision
+print(value ^ (2 ** 32), "\n");
+print(value << 1, "\n");
+printFlush();

--- a/compiler/test/out/constant_bitwise.mlog
+++ b/compiler/test/out/constant_bitwise.mlog
@@ -1,0 +1,9 @@
+print 8
+print "\n"
+print 8589934592
+print "\n"
+print 12884901888
+print "\n"
+print 17179869184
+print "\n"
+printflush message1


### PR DESCRIPTION
Fixes the compile-time evaluation of most operators, specially the bitwise operators, by:
- Converting the left side and right side values (if present) into their mlog number equivalent (except for the `+` operator, in order to not break constant string concatenation).
- Using `bigint`s to get 64-bit accuracy in bitwise operators, since javascript's numbers are converted into 32-bit ints to perform bitwise operations.