### PR TITLE
Remove support for operator overriding

### DIFF
--- a/compiler/CHANGELOG.md
+++ b/compiler/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Removed support for object operator overriding.
 - Removed support for the `typeof` operator.
 
 ### Fixed

--- a/compiler/src/types.ts
+++ b/compiler/src/types.ts
@@ -2,8 +2,6 @@ export * as es from "@babel/types";
 import * as es from "@babel/types";
 import { Compiler } from "./Compiler";
 import { AddressResolver } from "./instructions";
-import { MacroFunction } from "./macros";
-import { LeftRightOperator, UnaryOperator, UpdateOperator } from "./operators";
 
 export enum EInstIntent {
   none,
@@ -351,11 +349,3 @@ export type TValueInstructions<Content extends IValue | null = IValue> = [
   Content,
   IInstruction[],
 ];
-
-/** Map of overridable operators in object macros */
-export type TOperatorMacroMap = {
-  [K in
-    | UnaryOperator
-    | UpdateOperator
-    | LeftRightOperator as `$${K}`]?: MacroFunction;
-};

--- a/website/docs/guide/data-types.md
+++ b/website/docs/guide/data-types.md
@@ -54,19 +54,13 @@ function add(a, b) {
 
 ## Object
 
-Object values are constants and support operator overriding.
+Object values are constants.
 
 ```js
 const obj = {
   a: 1,
   b: (a, b) => a + b,
-  $call: (a, b) => a * b,
 };
 obj.a; // 1
 obj.b(1, 2); // 3
-obj(2, 2); // 4
 ```
-
-::: warning
-Note that operator overriding cannot be checked by typescript, so its use is not recommended.
-:::


### PR DESCRIPTION
This feature is being removed for two main reasons:
- It is not something that works in regular javascript
- Keeping it would make moving onto the model proposed by #212 significantly more difficult than it needs to be.