### PR TITLE
More math functions

### DIFF
--- a/compiler/CHANGELOG.md
+++ b/compiler/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added custom implementations for more math functions:
+  - `Math.sign`
+  - `Math.round`
+  - `Math.trunc`
+  - `Math.exp`
+  - `Math.expm1`
+  - `Math.cosh`
+  - `Math.acosh`
+  - `Math.sinh`
+  - `Math.asinh`
+  - `Math.tanh`
+  - `Math.atanh`
 - Added support for getters and setters.
 - Added brief documentation to some senseable properties.
 - Added typings for the `id` property on symbols.

--- a/compiler/lib/eslib/lib.es2015.core.d.ts
+++ b/compiler/lib/eslib/lib.es2015.core.d.ts
@@ -17,3 +17,62 @@ and limitations under the License.
 
 /** Does not exist. It's only here because typescript needs it */
 interface RegExp {}
+
+interface Math {
+  /**
+   * Returns the sign of the x, indicating whether x is positive, negative or zero.
+   * @param x The numeric expression to test
+   */
+  sign(x: number): number;
+
+  /**
+   * Returns the result of (e^x - 1), which is an implementation-dependent approximation to
+   * subtracting 1 from the exponential function of x (e raised to the power of x, where e
+   * is the base of the natural logarithms).
+   * @param x A numeric expression.
+   */
+  expm1(x: number): number;
+
+  /**
+   * Returns the hyperbolic cosine of a number.
+   * @param x A numeric expression that contains an angle measured in degrees.
+   */
+  cosh(x: number): number;
+
+  /**
+   * Returns the hyperbolic sine of a number.
+   * @param x A numeric expression that contains an angle measured in degrees.
+   */
+  sinh(x: number): number;
+
+  /**
+   * Returns the hyperbolic tangent of a number.
+   * @param x A numeric expression that contains an angle measured in degrees.
+   */
+  tanh(x: number): number;
+
+  /**
+   * Returns the inverse hyperbolic cosine of a number.
+   * @param x A numeric expression that contains an angle measured in degrees.
+   */
+  acosh(x: number): number;
+
+  /**
+   * Returns the inverse hyperbolic sine of a number.
+   * @param x A numeric expression that contains an angle measured in degrees.
+   */
+  asinh(x: number): number;
+
+  /**
+   * Returns the inverse hyperbolic tangent of a number.
+   * @param x A numeric expression that contains an angle measured in degrees.
+   */
+  atanh(x: number): number;
+
+  /**
+   * Returns the integral part of the a numeric expression, x, removing any fractional digits.
+   * If x is already an integer, the result is x.
+   * @param x A numeric expression.
+   */
+  trunc(x: number): number;
+}

--- a/compiler/lib/eslib/lib.es5.d.ts
+++ b/compiler/lib/eslib/lib.es5.d.ts
@@ -201,6 +201,18 @@ interface Math {
    * @param y The exponent value of the expression.
    */
   pow(x: number, y: number): number;
+
+  /**
+   * Returns a supplied numeric expression rounded to the nearest integer.
+   * @param x The value to be rounded to the nearest integer.
+   */
+  round(x: number): number;
+
+  /**
+   * Returns e (the base of natural logarithms) raised to a power.
+   * @param x A numeric expression representing the power of e.
+   */
+  exp(x: number): number;
 }
 declare const Math: Math;
 

--- a/compiler/src/handlers/Object.ts
+++ b/compiler/src/handlers/Object.ts
@@ -71,11 +71,11 @@ export const ArrayExpression: THandler = (
   node: es.ArrayExpression,
   out,
 ) => {
-  const items: (IValue | undefined)[] = [];
+  const items: IValue[] = [];
   const inst: IInstruction[] = [];
   node.elements.forEach((element, i) => {
     if (!element) {
-      items.push(undefined);
+      items.push(new LiteralValue(null));
       return;
     }
     const value = pipeInsts(

--- a/compiler/src/macros/Math.ts
+++ b/compiler/src/macros/Math.ts
@@ -73,6 +73,20 @@ function createMacroMathOperations() {
       const result = pipeInsts(floor!.call(scope, [incremented], out), inst)!;
       return [result, inst];
     }),
+    trunc: new MacroFunction((scope, out, x) => {
+      assertArgumentCount(+!!x, 1);
+
+      // subtracts the decimal part of a number from itself
+      // works with both positive and negative numbers,
+      // returning the integer part of the number
+
+      // return a - (a % 1);
+      const inst: IInstruction[] = [];
+      const one = new LiteralValue(1);
+      const rest = pipeInsts(x["%"](scope, one), inst);
+      const result = pipeInsts(x["-"](scope, rest, out), inst);
+      return [result, inst];
+    }),
   };
   for (const key in mathOperations) {
     const fn = mathOperations[key];

--- a/compiler/src/macros/Math.ts
+++ b/compiler/src/macros/Math.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { CompilerError } from "../CompilerError";
 import { OperationInstruction } from "../instructions";
-import { EMutability, IInstruction, IValue } from "../types";
-import { pipeInsts } from "../utils";
+import { IInstruction, IValue } from "../types";
+import { mathConstants, pipeInsts } from "../utils";
 import {
   IObjectValueData,
   LiteralValue,
@@ -58,10 +58,10 @@ const orderIndependentOperations = ["max", "min", "len"];
 
 function createMacroMathOperations() {
   const macroMathOperations: IObjectValueData = {
-    PI: new StoreValue("@pi", EMutability.constant),
-    E: new StoreValue("@e", EMutability.constant),
-    degToRad: new StoreValue("@degToRad", EMutability.constant),
-    radToDeg: new StoreValue("@radToDeg", EMutability.constant),
+    PI: new LiteralValue(mathConstants.PI),
+    E: new LiteralValue(mathConstants.E),
+    degToRad: new LiteralValue(mathConstants.degToRad),
+    radToDeg: new LiteralValue(mathConstants.radToDeg),
     sign: new MacroFunction((scope, out, x) => {
       assertArgumentCount(+!!x, 1);
 

--- a/compiler/src/macros/Math.ts
+++ b/compiler/src/macros/Math.ts
@@ -181,6 +181,38 @@ function createMacroMathOperations() {
       const degrees = pipeInsts(radians["*"](scope, radToDeg), inst);
       return [degrees, inst];
     }),
+    tanh: new MacroFunction((scope, out, degrees) => {
+      assertArgumentCount(+!!degrees, 1);
+
+      // const x = degrees * Math.degToRad;
+      // return (Math.exp(x) - Math.exp(-x)) / (Math.exp(x) + Math.exp(-x));
+      const { exp, degToRad } = macroMathOperations;
+      const inst: IInstruction[] = [];
+      const x = pipeInsts(degrees["*"](scope, degToRad), inst);
+      const expx = pipeInsts(exp.call(scope, [x]), [])!;
+      const negativeX = pipeInsts(x["u-"](scope), inst);
+      const expnegx = pipeInsts(exp.call(scope, [negativeX]), inst)!;
+      const sub = pipeInsts(expx["-"](scope, expnegx), inst);
+      const sum = pipeInsts(expx["+"](scope, expnegx), inst);
+      const result = pipeInsts(sub["/"](scope, sum, out), inst);
+      return [result, inst];
+    }),
+    atanh: new MacroFunction((scope, out, x) => {
+      assertArgumentCount(+!!x, 1);
+
+      // return (Math.log((1 + x) / (1 - x)) / 2) * Math.radToDeg;
+      const { log, radToDeg } = macroMathOperations;
+      const inst: IInstruction[] = [];
+      const one = new LiteralValue(1);
+      const two = new LiteralValue(2);
+      const sum = pipeInsts(one["+"](scope, x), inst);
+      const sub = pipeInsts(one["-"](scope, x), inst);
+      const div = pipeInsts(sum["/"](scope, sub), inst);
+      const logOfDiv = pipeInsts(log.call(scope, [div]), inst)!;
+      const radians = pipeInsts(logOfDiv["/"](scope, two, out), inst);
+      const degrees = pipeInsts(radians["*"](scope, radToDeg), inst);
+      return [degrees, inst];
+    }),
   };
   for (const key in mathOperations) {
     const fn = mathOperations[key];

--- a/compiler/src/macros/Math.ts
+++ b/compiler/src/macros/Math.ts
@@ -84,7 +84,7 @@ function createMacroMathOperations() {
       const half = new LiteralValue(0.5);
       const incremented = pipeInsts(x["+"](scope, half), inst);
       const { floor } = macroMathOperations;
-      const result = pipeInsts(floor!.call(scope, [incremented], out), inst)!;
+      const result = pipeInsts(floor.call(scope, [incremented], out), inst)!;
       return [result, inst];
     }),
     trunc: new MacroFunction((scope, out, x) => {

--- a/compiler/src/macros/Math.ts
+++ b/compiler/src/macros/Math.ts
@@ -62,6 +62,20 @@ function createMacroMathOperations() {
     E: new StoreValue("@e", EMutability.constant),
     degToRad: new StoreValue("@degToRad", EMutability.constant),
     radToDeg: new StoreValue("@radToDeg", EMutability.constant),
+    sign: new MacroFunction((scope, out, x) => {
+      assertArgumentCount(+!!x, 1);
+
+      // inspired by the branchless sign function from
+      // https://stackoverflow.com/a/14612943/13745435
+
+      // return (a > 0) - (a < 0);
+      const inst: IInstruction[] = [];
+      const zero = new LiteralValue(0);
+      const gt = pipeInsts(x[">"](scope, zero), inst);
+      const lt = pipeInsts(x["<"](scope, zero), inst);
+      const result = pipeInsts(gt["-"](scope, lt, out), inst);
+      return [result, inst];
+    }),
     round: new MacroFunction((scope, out, x) => {
       assertArgumentCount(+!!x, 1);
 

--- a/compiler/src/macros/Math.ts
+++ b/compiler/src/macros/Math.ts
@@ -101,6 +101,27 @@ function createMacroMathOperations() {
       const result = pipeInsts(x["-"](scope, rest, out), inst);
       return [result, inst];
     }),
+    exp: new MacroFunction((scope, out, x) => {
+      assertArgumentCount(+!!x, 1);
+
+      // return Math.E ** x;
+      const inst: IInstruction[] = [];
+
+      const { E } = macroMathOperations;
+      const result = pipeInsts(E["**"](scope, x, out), inst);
+      return [result, inst];
+    }),
+    expm1: new MacroFunction((scope, out, x) => {
+      assertArgumentCount(+!!x, 1);
+
+      // return Math.exp(x) - 1;
+      const inst: IInstruction[] = [];
+      const { exp } = macroMathOperations;
+      const ex = pipeInsts(exp.call(scope, [x]), inst)!;
+      const one = new LiteralValue(1);
+      const subtracted = pipeInsts(ex["-"](scope, one, out), inst);
+      return [subtracted, inst];
+    }),
   };
   for (const key in mathOperations) {
     const fn = mathOperations[key];

--- a/compiler/src/macros/Math.ts
+++ b/compiler/src/macros/Math.ts
@@ -157,9 +157,9 @@ function createMacroMathOperations() {
 
       // const x = degrees * Math.degToRad;
       // return (Math.exp(x) - Math.exp(-x)) / 2;
-      const { exp, radToDeg } = macroMathOperations;
+      const { exp, degToRad } = macroMathOperations;
       const inst: IInstruction[] = [];
-      const x = pipeInsts(degrees["*"](scope, radToDeg), inst);
+      const x = pipeInsts(degrees["*"](scope, degToRad), inst);
       const expx = pipeInsts(exp.call(scope, [x]), [])!;
       const negativeX = pipeInsts(x["u-"](scope), inst);
       const expnegx = pipeInsts(exp.call(scope, [negativeX]), inst)!;

--- a/compiler/src/macros/Math.ts
+++ b/compiler/src/macros/Math.ts
@@ -122,6 +122,36 @@ function createMacroMathOperations() {
       const subtracted = pipeInsts(ex["-"](scope, one, out), inst);
       return [subtracted, inst];
     }),
+    cosh: new MacroFunction((scope, out, degrees) => {
+      assertArgumentCount(+!!degrees, 1);
+
+      // const x = degrees * Math.degToRad;
+      // return (Math.exp(x) + Math.exp(-x)) / 2;
+      const { exp, degToRad } = macroMathOperations;
+      const inst: IInstruction[] = [];
+      const x = pipeInsts(degrees["*"](scope, degToRad), inst);
+      const expx = pipeInsts(exp.call(scope, [x]), [])!;
+      const negativeX = pipeInsts(x["u-"](scope), inst);
+      const expnegx = pipeInsts(exp.call(scope, [negativeX]), inst)!;
+      const sum = pipeInsts(expx["+"](scope, expnegx), inst);
+      const result = pipeInsts(sum["/"](scope, new LiteralValue(2), out), inst);
+      return [result, inst];
+    }),
+    acosh: new MacroFunction((scope, out, x) => {
+      assertArgumentCount(+!!x, 1);
+
+      // return Math.log(x + Math.sqrt(x ** 2 - 1)) * Math.radToDeg;
+      const { log, sqrt, radToDeg } = macroMathOperations;
+      const inst: IInstruction[] = [];
+      const x2 = pipeInsts(x["**"](scope, new LiteralValue(2)), inst);
+      const one = new LiteralValue(1);
+      const x2minus1 = pipeInsts(x2["-"](scope, one), inst);
+      const sqrtx2minus1 = pipeInsts(sqrt.call(scope, [x2minus1]), inst)!;
+      const sum = pipeInsts(x["+"](scope, sqrtx2minus1), inst);
+      const radians = pipeInsts(log.call(scope, [sum], out), inst)!;
+      const degrees = pipeInsts(radians["*"](scope, radToDeg), inst);
+      return [degrees, inst];
+    }),
   };
   for (const key in mathOperations) {
     const fn = mathOperations[key];

--- a/compiler/src/macros/Math.ts
+++ b/compiler/src/macros/Math.ts
@@ -152,6 +152,35 @@ function createMacroMathOperations() {
       const degrees = pipeInsts(radians["*"](scope, radToDeg), inst);
       return [degrees, inst];
     }),
+    sinh: new MacroFunction((scope, out, degrees) => {
+      assertArgumentCount(+!!degrees, 1);
+
+      // const x = degrees * Math.degToRad;
+      // return (Math.exp(x) - Math.exp(-x)) / 2;
+      const { exp, radToDeg } = macroMathOperations;
+      const inst: IInstruction[] = [];
+      const x = pipeInsts(degrees["*"](scope, radToDeg), inst);
+      const expx = pipeInsts(exp.call(scope, [x]), [])!;
+      const negativeX = pipeInsts(x["u-"](scope), inst);
+      const expnegx = pipeInsts(exp.call(scope, [negativeX]), inst)!;
+      const sub = pipeInsts(expx["-"](scope, expnegx), inst);
+      const result = pipeInsts(sub["/"](scope, new LiteralValue(2)), inst);
+      return [result, inst];
+    }),
+    asinh: new MacroFunction((scope, out, x) => {
+      assertArgumentCount(+!!x, 1);
+
+      // return Math.log(x + Math.sqrt(x ** 2 + 1)) * Math.radToDeg;
+      const { log, sqrt, radToDeg } = macroMathOperations;
+      const inst: IInstruction[] = [];
+      const x2 = pipeInsts(x["**"](scope, new LiteralValue(2)), inst);
+      const x2plus1 = pipeInsts(x2["+"](scope, new LiteralValue(1)), inst);
+      const sqrtx2plus1 = pipeInsts(sqrt.call(scope, [x2plus1]), inst)!;
+      const sum = pipeInsts(x["+"](scope, sqrtx2plus1), inst);
+      const radians = pipeInsts(log.call(scope, [sum], out), inst)!;
+      const degrees = pipeInsts(radians["*"](scope, radToDeg), inst);
+      return [degrees, inst];
+    }),
   };
   for (const key in mathOperations) {
     const fn = mathOperations[key];

--- a/compiler/src/utils/constants.ts
+++ b/compiler/src/utils/constants.ts
@@ -30,3 +30,10 @@ export const itemNames = [
 /** The name of a special processor variable, controls the instruction pointer */
 export const counterName = "@counter";
 export const worldModuleName = "mlogjs:world";
+
+export const mathConstants = {
+  E: Math.E,
+  PI: Math.PI,
+  radToDeg: 180 / Math.PI,
+  degToRad: Math.PI / 180,
+};

--- a/compiler/src/values/LiteralValue.ts
+++ b/compiler/src/values/LiteralValue.ts
@@ -10,6 +10,7 @@ import {
 import { BaseValue } from ".";
 import { BinaryOperator, LogicalOperator, UnaryOperator } from "../operators";
 import { CompilerError } from "../CompilerError";
+import { mathConstants } from "../utils";
 
 const literalMethods: Record<
   string,
@@ -41,6 +42,22 @@ export class LiteralValue<T extends TLiteral | null = TLiteral>
   }
   toMlogString() {
     const { data } = this;
+
+    // math constants are literal values
+    // so that the compiler can optimize them
+    // in operations
+    // this helps to print them in their global variable form
+    // instead of their literal value
+    switch (data) {
+      case mathConstants.E:
+        return "@e";
+      case mathConstants.PI:
+        return "@pi";
+      case mathConstants.degToRad:
+        return "@degToRad";
+      case mathConstants.radToDeg:
+        return "@radToDeg";
+    }
     if (typeof data !== "string") return JSON.stringify(data);
 
     // this special handling is required because of

--- a/compiler/src/values/ObjectValue.ts
+++ b/compiler/src/values/ObjectValue.ts
@@ -10,7 +10,7 @@ import { LiteralValue } from "./LiteralValue";
 import { VoidValue } from "./VoidValue";
 
 export interface IObjectValueData {
-  [k: string]: IValue | undefined;
+  [k: string]: IValue;
 }
 export class ObjectValue extends VoidValue {
   mutability = EMutability.constant;
@@ -41,8 +41,7 @@ export class ObjectValue extends VoidValue {
       // avoids naming collisions with keys like
       // constructor or toString
       if (Object.prototype.hasOwnProperty.call(this.data, key.data)) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const member = this.data[key.data]!;
+        const member = this.data[key.data];
         if (out) return member.eval(scope, out);
         return [member, []];
       }

--- a/compiler/test/fail/array_des_missing_prop.js
+++ b/compiler/test/fail/array_des_missing_prop.js
@@ -1,4 +1,4 @@
-// The target object does not have a value at index 1
+// The target object does not have a value at index 3
 
 const elements = [1, , 2];
-const [a, b, c] = elements;
+const [a, b, c, d] = elements;

--- a/compiler/test/in/math.js
+++ b/compiler/test/in/math.js
@@ -21,6 +21,17 @@ Math.atan(a);
 Math.idiv(a, 2);
 Math.pow(a, 2);
 Math.angleDiff(a, -5);
+Math.sign(a);
+Math.round(a);
+Math.trunc(a);
+Math.exp(a);
+Math.expm1(a);
+Math.cosh(a);
+Math.acosh(a);
+Math.sinh(a);
+Math.asinh(a);
+Math.tanh(a);
+Math.atanh(a);
 
 // compile time evaluation
 
@@ -47,6 +58,17 @@ temp = Math.atan(10.5);
 temp = Math.idiv(5, 2);
 temp = Math.pow(2, 9);
 temp = Math.angleDiff(10, -35);
+temp = Math.sign(10);
+temp = Math.round(10.5);
+temp = Math.trunc(-1.2);
+temp = Math.exp(1);
+temp = Math.expm1(1);
+temp = Math.cosh(180);
+temp = Math.acosh(11.5919);
+temp = Math.sinh(90);
+temp = Math.asinh(2.3);
+temp = Math.tanh(180);
+temp = Math.atanh(0.99627);
 
 print`
 ${Math.PI}

--- a/compiler/test/out/math.mlog
+++ b/compiler/test/out/math.mlog
@@ -21,28 +21,83 @@ op atan &_ a:1:4
 op idiv &_ a:1:4 2
 op pow &_ a:1:4 2
 op angleDiff &_ a:1:4 -5
-set temp:28:4 0
-set temp:28:4 20
-set temp:28:4 10.5
-set temp:28:4 62.300527191945
-set temp:28:4 22.588713996153036
-op noise temp:28:4 10.5 20
-set temp:28:4 10.5
-set temp:28:4 2.3513752571634776
-set temp:28:4 1.021189299069938
-set temp:28:4 0.18223552549214747
-set temp:28:4 0.9832549075639546
-set temp:28:4 0.18533904493153439
-set temp:28:4 10
-set temp:28:4 11
-set temp:28:4 3.24037034920393
-op rand temp:28:4 10.5
-set temp:28:4 null
-set temp:28:4 null
-set temp:28:4 84.5596679689945
-set temp:28:4 2
-set temp:28:4 512
-set temp:28:4 45
+op greaterThan &t0 a:1:4 0
+op lessThan &t1 a:1:4 0
+op sub &_ &t0 &t1
+op add &t2 a:1:4 0.5
+op floor &_ &t2
+op mod &t3 a:1:4 1
+op sub &_ a:1:4 &t3
+op pow &_ @e a:1:4
+op pow &t4 @e a:1:4
+op sub &_ &t4 1
+op mul &t5 a:1:4 @degToRad
+op sub &t7 0 &t5
+op pow &t8 @e &t7
+op add &t9 &t6 &t8
+op div &_ &t9 2
+op pow &t10 a:1:4 2
+op sub &t11 &t10 1
+op sqrt &t12 &t11
+op add &t13 a:1:4 &t12
+op log &_ &t13
+op mul &t14 &_ @radToDeg
+op mul &t15 a:1:4 @degToRad
+op sub &t17 0 &t15
+op pow &t18 @e &t17
+op sub &t19 &t16 &t18
+op div &t20 &t19 2
+op pow &t21 a:1:4 2
+op add &t22 &t21 1
+op sqrt &t23 &t22
+op add &t24 a:1:4 &t23
+op log &_ &t24
+op mul &t25 &_ @radToDeg
+op mul &t26 a:1:4 @degToRad
+op sub &t28 0 &t26
+op pow &t29 @e &t28
+op sub &t30 &t27 &t29
+op add &t31 &t27 &t29
+op div &_ &t30 &t31
+op add &t32 1 a:1:4
+op sub &t33 1 a:1:4
+op div &t34 &t32 &t33
+op log &t35 &t34
+op div &_ &t35 2
+op mul &t36 &_ @radToDeg
+set temp:39:4 0
+set temp:39:4 20
+set temp:39:4 10.5
+set temp:39:4 62.300527191945
+set temp:39:4 22.588713996153036
+op noise temp:39:4 10.5 20
+set temp:39:4 10.5
+set temp:39:4 2.3513752571634776
+set temp:39:4 1.021189299069938
+set temp:39:4 0.18223552549214747
+set temp:39:4 0.9832549075639546
+set temp:39:4 0.18533904493153439
+set temp:39:4 10
+set temp:39:4 11
+set temp:39:4 3.24037034920393
+op rand temp:39:4 10.5
+set temp:39:4 null
+set temp:39:4 null
+set temp:39:4 84.5596679689945
+set temp:39:4 2
+set temp:39:4 512
+set temp:39:4 45
+set temp:39:4 1
+set temp:39:4 11
+set temp:39:4 -1
+set temp:39:4 @e
+set temp:39:4 1.718281828459045
+set temp:39:4 11.591953275521517
+set temp:39:4 179.99973568806888
+set temp:39:4 2.3012989023072943
+set temp:39:4 89.97033320163936
+set temp:39:4 0.9962720762207501
+set temp:39:4 179.98401956048068
 print "\n"
 print @pi
 print "\n"


### PR DESCRIPTION
Adds custom implementations for the following math functions:

- `Math.sign`
  ```js
  Math.sign = (x: number) => {
    return (x > 0) - (x < 0);
  };
  ```
- `Math.round`
  ```js
  Math.round = (x: number) => {
    return Math.floor(x + 0.5);
  };
  ```
- `Math.trunc`
  ```js
  Math.trunc = (x: number) => {
    return x - (x % 1);
  };
  ```
- `Math.exp`
  ```js
  Math.exp = (x: number) => {
    return Math.pow(Math.E, x);
  };
  ```
- `Math.expm1`
  ```js
  Math.expm1 = (x: number) => {
    return Math.exp(x) - 1;
  };
  ```
- `Math.cosh`
  ```js
  Math.cosh = (degrees: number) => {
    const x = degrees * Math.degToRad;
    return (Math.exp(x) + Math.exp(-x)) / 2;
  };
  ```
- `Math.acosh`
  ```js
  Math.acosh = (x: number) => {
    return Math.log(x + Math.sqrt(x ** 2 - 1)) * Math.radToDeg;
  };
  ```
- `Math.sinh`
  ```js
  Math.sinh = (: number) => {
    const x = degrees * Math.degToRad;
    return (Math.exp(x) - Math.exp(-x)) / 2;
  };
  ```
- `Math.asinh`
  ```js
  Math.asinh = (x: number) => {
    return Math.log(x + Math.sqrt(x ** 2 + 1)) * Math.radToDeg;
  };
  ```
- `Math.tanh`
  ```js
  Math.tanh = (degrees: number) => {
    const x = degrees * Math.degToRad;
    return (Math.exp(x) - Math.exp(-x)) / (Math.exp(x) + Math.exp(-x));
  };
  ```
- `Math.atanh`
  ```js
  Math.atanh = (x: number) => {
    return (Math.log((1 + x) / (1 - x)) / 2) * Math.radToDeg;
  };
  ```

For the sake of consistency with the mlog trigonometric functions, these ones also use degrees instead of radians.