### PR TITLE
Add integration with MlogWatcher via websockets

### DIFF
--- a/website/docs/guide/getting-started.md
+++ b/website/docs/guide/getting-started.md
@@ -32,6 +32,17 @@ The quickest way to get started on the compiler is with the
   Your browser does not support the video tag.
   </video>
 
+- ### Integration with [Mlog Watcher](https://github.com/Sharlottes/MlogWatcher)
+
+  Send the compiled code to your currently selected processor by pressing <kbd>Ctrl</kbd>+<kbd>S</kbd> or enabling auto sending.
+
+  You can enable this functionality in the settings.
+
+  <video autoplay loop muted>
+  <source src="https://github.com/Sharlottes/MlogWatcher/assets/61994401/4df1ba70-d9dc-4b9b-935d-e11e2c2f2d46">
+  Your browser does not support the video tag.
+  </video>
+
 ## Local setup
 
 This section assumes that you are familiar with the following concepts:

--- a/website/src/components/MlogEditor.vue
+++ b/website/src/components/MlogEditor.vue
@@ -77,7 +77,7 @@ useSourceMapping({
   monacoRef,
 });
 
-useMlogWatcherSocket(9992, compiledRef);
+useMlogWatcherSocket(settings, compiledRef);
 
 const language = computed(() => {
   const file = currentFile.value;

--- a/website/src/components/MlogEditor.vue
+++ b/website/src/components/MlogEditor.vue
@@ -99,13 +99,20 @@ watchEffect(onCleanup => {
   onCleanup(() => disposable.dispose());
 });
 
-watchEffect(() => {
-  const monaco = monacoRef.value;
-  const editor = editorRef.value;
-  if (!editor || !monaco) return;
-
-  editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {
+watchEffect(onCleanup => {
+  // global event handler to
+  // allow the user to press ctrl+s
+  // without needing to focus the editor
+  function handler(e: KeyboardEvent) {
+    if (!e.ctrlKey || e.key !== "s") return;
+    e.preventDefault();
     sendToMlogWatcher();
+  }
+
+  window.addEventListener("keydown", handler);
+
+  onCleanup(() => {
+    window.removeEventListener("keydown", handler);
   });
 });
 

--- a/website/src/components/MlogEditor.vue
+++ b/website/src/components/MlogEditor.vue
@@ -26,6 +26,7 @@ import MonacoEditor, {
   useMonacoTheme,
 } from "@jeanjpnm/monaco-vue";
 import "@jeanjpnm/monaco-vue/style.css";
+import { useMlogWatcherSocket } from "../composables/useMlogWatcherSocket";
 const { isDark } = useData();
 
 const theme = computed(() => (isDark.value ? "vs-dark" : "vs"));
@@ -75,6 +76,8 @@ useSourceMapping({
   sourcemapsRef,
   monacoRef,
 });
+
+useMlogWatcherSocket(9992, compiledRef);
 
 const language = computed(() => {
   const file = currentFile.value;

--- a/website/src/components/MlogEditor.vue
+++ b/website/src/components/MlogEditor.vue
@@ -77,7 +77,7 @@ useSourceMapping({
   monacoRef,
 });
 
-useMlogWatcherSocket(settings, compiledRef);
+const sendToMlogWatcher = useMlogWatcherSocket(settings, compiledRef);
 
 const language = computed(() => {
   const file = currentFile.value;
@@ -97,6 +97,16 @@ watchEffect(onCleanup => {
 
   const disposable = addWorldModuleSnippet(monaco);
   onCleanup(() => disposable.dispose());
+});
+
+watchEffect(() => {
+  const monaco = monacoRef.value;
+  const editor = editorRef.value;
+  if (!editor || !monaco) return;
+
+  editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {
+    sendToMlogWatcher();
+  });
 });
 
 function onReady(editor: monaco.editor.IStandaloneCodeEditor) {

--- a/website/src/components/SettingsDialog.vue
+++ b/website/src/components/SettingsDialog.vue
@@ -93,7 +93,11 @@ function onClose() {
         </label>
       </fieldset>
       <fieldset>
-        <legend>Mlog Watcher</legend>
+        <legend>Mlog Watcher Integration</legend>
+        <label>
+          Enabled
+          <input type="checkbox" v-model="settings.mlogWatcher.enabled" />
+        </label>
         <label>
           Auto Send
           <input

--- a/website/src/components/SettingsDialog.vue
+++ b/website/src/components/SettingsDialog.vue
@@ -92,6 +92,25 @@ function onClose() {
           />
         </label>
       </fieldset>
+      <fieldset>
+        <legend>Mlog Watcher</legend>
+        <label>
+          Auto Send
+          <input
+            type="checkbox"
+            name="mlog-watcher-auto-send"
+            v-model="settings.mlogWatcher.autoSend"
+          />
+        </label>
+        <label>
+          Server port
+          <input
+            type="number"
+            name="mlog-watcher-server-port"
+            v-model.lazy="settings.mlogWatcher.serverPort"
+          />
+        </label>
+      </fieldset>
       <button class="save" type="submit" @click="onClose">Save</button>
     </form>
   </dialog>
@@ -115,6 +134,16 @@ fieldset {
 label {
   display: flex;
   justify-content: space-between;
+}
+
+input {
+  font-family: var(--vp-font-family-base);
+  text-align: right;
+}
+
+input[name="mlog-watcher-server-port"] {
+  width: 4em;
+  border-bottom: 2px solid var(--vp-c-border);
 }
 
 button.save {

--- a/website/src/composables/useEditorSettings.ts
+++ b/website/src/composables/useEditorSettings.ts
@@ -16,6 +16,10 @@ export interface EditorSettings {
   editor: {
     confirmFileDeletion: boolean;
   };
+  mlogWatcher: {
+    autoSend: boolean;
+    serverPort: number;
+  };
 }
 
 export type EditorSettingsRef = Ref<EditorSettings>;
@@ -62,6 +66,10 @@ function getDefaultSettings(): EditorSettings {
       noImplicitAny: false,
       strict: false,
       strictNullChecks: false,
+    },
+    mlogWatcher: {
+      autoSend: true,
+      serverPort: 9992,
     },
   };
 }

--- a/website/src/composables/useEditorSettings.ts
+++ b/website/src/composables/useEditorSettings.ts
@@ -17,6 +17,7 @@ export interface EditorSettings {
     confirmFileDeletion: boolean;
   };
   mlogWatcher: {
+    enabled: boolean;
     autoSend: boolean;
     serverPort: number;
   };
@@ -68,7 +69,8 @@ function getDefaultSettings(): EditorSettings {
       strictNullChecks: false,
     },
     mlogWatcher: {
-      autoSend: true,
+      enabled: false,
+      autoSend: false,
       serverPort: 9992,
     },
   };

--- a/website/src/composables/useMlogWatcherSocket.ts
+++ b/website/src/composables/useMlogWatcherSocket.ts
@@ -10,7 +10,11 @@ export function useMlogWatcherSocket(
   const port = computed(() => settingsRef.value.mlogWatcher.serverPort);
   const autoSend = computed(() => settingsRef.value.mlogWatcher.autoSend);
 
-  const send = debounce(700, (code: string) => {
+  const send = (code: string) => {
+    socket.value?.send(code);
+  };
+
+  const debouncedSend = debounce(700, (code: string) => {
     socket.value?.send(code);
   });
 
@@ -27,8 +31,10 @@ export function useMlogWatcherSocket(
   });
 
   watchEffect(() => {
-    if (ready.value && autoSend.value) send(code.value);
+    if (ready.value && autoSend.value) debouncedSend(code.value);
   });
+
+  return () => send(code.value);
 }
 
 function debounce<Args extends unknown[]>(

--- a/website/src/composables/useMlogWatcherSocket.ts
+++ b/website/src/composables/useMlogWatcherSocket.ts
@@ -1,0 +1,44 @@
+import { onMounted, onUnmounted, watchEffect, type Ref, ref } from "vue";
+
+export function useMlogWatcherSocket(port: number, code: Ref<string>) {
+  const socket = ref<WebSocket>();
+  const ready = ref(false);
+
+  const send = debounce(700, (code: string) => {
+    socket.value?.send(code);
+  });
+
+  onMounted(() => {
+    const websocket = new WebSocket(`ws://localhost:${port}`);
+    socket.value = websocket;
+    websocket.onopen = () => {
+      console.log("opened");
+      ready.value = true;
+    };
+    websocket.onerror = event => {
+      console.log(event);
+    };
+  });
+
+  onUnmounted(() => {
+    socket.value?.close();
+  });
+
+  watchEffect(() => {
+    console.log("changed");
+    if (ready.value) send(code.value);
+  });
+}
+
+function debounce<Args extends unknown[]>(
+  delay: number,
+  fn: (...args: Args) => unknown,
+) {
+  let timer: number | undefined;
+
+  return (...args: Args) => {
+    clearTimeout(timer);
+
+    timer = setTimeout(() => fn(...args), delay) as never;
+  };
+}

--- a/website/src/composables/useMlogWatcherSocket.ts
+++ b/website/src/composables/useMlogWatcherSocket.ts
@@ -24,6 +24,9 @@ export function useMlogWatcherSocket(
     websocket.onopen = () => {
       ready.value = true;
     };
+    websocket.onclose = () => {
+      ready.value = false;
+    };
     socket.value = websocket;
 
     onCleanup(() => {

--- a/website/src/composables/useMlogWatcherSocket.ts
+++ b/website/src/composables/useMlogWatcherSocket.ts
@@ -7,6 +7,7 @@ export function useMlogWatcherSocket(
 ) {
   const socket = ref<WebSocket>();
   const ready = ref(false);
+  const manuallyTriggered = ref(false);
   const port = computed(() => settingsRef.value.mlogWatcher.serverPort);
   const autoSend = computed(() => settingsRef.value.mlogWatcher.autoSend);
 
@@ -34,7 +35,14 @@ export function useMlogWatcherSocket(
     if (ready.value && autoSend.value) debouncedSend(code.value);
   });
 
-  return () => send(code.value);
+  watchEffect(() => {
+    if (ready.value && manuallyTriggered.value) {
+      send(code.value);
+      manuallyTriggered.value = false;
+    }
+  });
+
+  return () => (manuallyTriggered.value = true);
 }
 
 function debounce<Args extends unknown[]>(

--- a/website/src/composables/useMlogWatcherSocket.ts
+++ b/website/src/composables/useMlogWatcherSocket.ts
@@ -10,6 +10,7 @@ export function useMlogWatcherSocket(
   const manuallyTriggered = ref(false);
   const port = computed(() => settingsRef.value.mlogWatcher.serverPort);
   const autoSend = computed(() => settingsRef.value.mlogWatcher.autoSend);
+  const enabled = computed(() => settingsRef.value.mlogWatcher.enabled);
 
   const send = (code: string) => {
     socket.value?.send(code);
@@ -20,6 +21,8 @@ export function useMlogWatcherSocket(
   });
 
   watchEffect(onCleanup => {
+    if (!enabled.value) return;
+
     const websocket = new WebSocket(`ws://localhost:${port.value}`);
     websocket.onopen = () => {
       ready.value = true;


### PR DESCRIPTION
Adds integration with the [MlogWatcher](https://github.com/Sharlottes/MlogWatcher) mod by creating a websocket connection and sending the compiled code after the user finishes typing.

Used in [this demo](https://github.com/Sharlottes/MlogWatcher/pull/3#issuecomment-1854155631) for Sharlottes/MlogWatcher#3