### PR TITLE
Allow control over inlining behavior via directives

### DIFF
--- a/compiler/CHANGELOG.md
+++ b/compiler/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a directive to control a function's inlining behavior
 - Added a watch mode to the CLI via the `--watch` flag.
 - Added custom implementations for more math functions:
   - `Math.sign`

--- a/compiler/src/types.ts
+++ b/compiler/src/types.ts
@@ -336,6 +336,12 @@ export interface IBindableValue<T extends TLiteral | null = TLiteral>
 }
 export type TLineRef = IBindableValue<number | null>;
 
+export enum EInlineType {
+  auto,
+  always,
+  never,
+}
+
 export interface IFunctionValue extends IValue {
   return(
     scope: IScope,

--- a/website/docs/guide/data-types.md
+++ b/website/docs/guide/data-types.md
@@ -45,6 +45,7 @@ output:
 ## Function
 
 Function values are constants.
+Functions [can be inlined](./syntax-support.md#functions)
 
 ```js
 function add(a, b) {

--- a/website/docs/guide/syntax-support.md
+++ b/website/docs/guide/syntax-support.md
@@ -181,6 +181,10 @@ Behavior:
   `inline never` can be used to tell the compiler that a function must never be inlined
   :::
 
+  ::: warning
+  Writing to the function parameters can cause undefined behavior when inlining.
+  :::
+
 Limitations:
 
 - Functions can only be bound to constants

--- a/website/docs/guide/syntax-support.md
+++ b/website/docs/guide/syntax-support.md
@@ -160,6 +160,27 @@ Behavior:
   }
   ```
 
+- Functions can be always/never inlined based on their `inline` directive:
+
+  ```js
+  // works with mixed types
+  print(distance({ x: Math.rand(Vars.mapw), y: 0 }, Vars.this));
+
+  print(distance(Vars.unit, Vars.this));
+
+  function distance(a, b) {
+    "inline";
+    return Math.len(a.x - b.x, a.y - b.y);
+  }
+  ```
+
+  ::: info
+  `inline` is used to tell the compiler that the function's body must be reevaluated on each call.
+  This drops many of the restrictions of regular function calls, allowing the use of higher order functions and more complicated objects as parameters.
+
+  `inline never` can be used to tell the compiler that a function must never be inlined
+  :::
+
 Limitations:
 
 - Functions can only be bound to constants


### PR DESCRIPTION
Allows users to control a function's inlining behavior, which enables features like having objects and other functions as function parameters, as well as improving performance in some scenarios.

This change is meant to mitigate part of the problem while #222 is still being worked on.