### PR TITLE
Add the `getColor` function

### DIFF
--- a/compiler/CHANGELOG.md
+++ b/compiler/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the `getColor` function to access color literals.
 - Added a directive to control a function's inlining behavior
 - Added a watch mode to the CLI via the `--watch` flag.
 - Added custom implementations for more math functions:

--- a/compiler/lib/helpers.d.ts
+++ b/compiler/lib/helpers.d.ts
@@ -39,6 +39,20 @@ declare global {
     T
   >;
 
+  /**
+   * Gets a color literal from a hex code.
+   *
+   * ```js
+   * const color = getColor("0e7eba");
+   *
+   * draw.col(color);
+   * draw.rect({ x: 0, y: 0, width: 500, height: 500 });
+   *
+   * drawFlush();
+   * ```
+   */
+  function getColor(hexCode: string): number;
+
   type ConcatLiteral = string | number | boolean | undefined;
 
   /**
@@ -71,11 +85,4 @@ declare global {
    * ```
    */
   function asm(strings: TemplateStringsArray, ...values: unknown[]): void;
-
-  /**
-   * Allows you to use an mlog color literal by specifiying it as a hex string.
-   *
-   * @param hexString
-   */
-  function getColor(hexString: string): number;
 }

--- a/compiler/lib/helpers.d.ts
+++ b/compiler/lib/helpers.d.ts
@@ -71,4 +71,11 @@ declare global {
    * ```
    */
   function asm(strings: TemplateStringsArray, ...values: unknown[]): void;
+
+  /**
+   * Allows you to use an mlog color literal by specifiying it as a hex string.
+   *
+   * @param hexString
+   */
+  function getColor(hexString: string): number;
 }

--- a/compiler/src/macros/GetColor.ts
+++ b/compiler/src/macros/GetColor.ts
@@ -1,0 +1,17 @@
+import { CompilerError } from "../CompilerError";
+import { EMutability } from "../types";
+import { LiteralValue, StoreValue } from "../values";
+import { MacroFunction } from "./Function";
+
+export class GetColor extends MacroFunction {
+  constructor() {
+    super((scope, out, color) => {
+      if (!(color instanceof LiteralValue) || !color.isString())
+        throw new CompilerError(
+          "The color parameter must be a string literal.",
+        );
+
+      return [new StoreValue(`%${color.data}`, EMutability.constant), []];
+    });
+  }
+}

--- a/compiler/src/macros/index.ts
+++ b/compiler/src/macros/index.ts
@@ -7,3 +7,5 @@ export { NamespaceMacro, VarsNamespace } from "./Namespace";
 export * from "./DynamicArray";
 export * from "./Unchecked";
 export * from "./GetBuildings";
+export * from "./GetGlobal";
+export * from "./GetColor";

--- a/compiler/src/modules.ts
+++ b/compiler/src/modules.ts
@@ -3,13 +3,14 @@ import {
   Concat,
   DynamicArrayConstructor,
   GetBuildings,
+  GetColor,
+  GetGlobal,
   MemoryBuilder,
   MlogMath,
   NamespaceMacro,
   Unchecked,
   VarsNamespace,
 } from "./macros";
-import { GetGlobal } from "./macros/GetGlobal";
 import { EMutability, IScope } from "./types";
 import { Asm } from "./macros/Asm";
 import { LiteralValue, ObjectValue } from "./values";
@@ -41,6 +42,7 @@ export function createGlobalScope(): IScope {
   scope.hardSet("getBuilding", new GetGlobal(EMutability.constant));
   scope.hardSet("getBuildings", new GetBuildings());
   scope.hardSet("getVar", new GetGlobal(EMutability.mutable));
+  scope.hardSet("getColor", new GetColor());
   scope.hardSet("concat", new Concat());
   scope.hardSet("asm", new Asm());
 

--- a/website/docs/guide/helper-methods.md
+++ b/website/docs/guide/helper-methods.md
@@ -26,6 +26,19 @@ buildings to multiple variables at once.
 const { switch1: toggle, cell1 } = getBuildings();
 ```
 
+## `getColor`
+
+Gets a color literal from a hex code.
+
+```js
+const color = getColor("0e7eba");
+
+draw.col(color);
+draw.rect({ x: 0, y: 0, width: 500, height: 500 });
+
+drawFlush();
+```
+
 ## `getVar`
 
 Allows you to access symbols or variables that are not available through the [namespaces](/guide/namespaces).

--- a/website/src/components/MlogEditor.vue
+++ b/website/src/components/MlogEditor.vue
@@ -27,6 +27,7 @@ import MonacoEditor, {
 } from "@jeanjpnm/monaco-vue";
 import "@jeanjpnm/monaco-vue/style.css";
 import { useMlogWatcherSocket } from "../composables/useMlogWatcherSocket";
+import { useColorPicker } from "../composables/useColorPicker";
 const { isDark } = useData();
 
 const theme = computed(() => (isDark.value ? "vs-dark" : "vs"));
@@ -76,6 +77,7 @@ useSourceMapping({
   sourcemapsRef,
   monacoRef,
 });
+useColorPicker({ editorRef, monacoRef });
 
 const sendToMlogWatcher = useMlogWatcherSocket(settings, compiledRef);
 

--- a/website/src/composables/useColorPicker.ts
+++ b/website/src/composables/useColorPicker.ts
@@ -1,0 +1,86 @@
+import type { editor, languages } from "monaco-editor";
+import { watchEffect, type ShallowRef } from "vue";
+import type { Monaco } from "../util";
+
+interface Params {
+  editorRef: ShallowRef<editor.IStandaloneCodeEditor | undefined>;
+  monacoRef: ShallowRef<Monaco | undefined>;
+}
+
+/**
+ * Adds a color picker for calls of `getColor` to let users easily see the
+ * colors they are embedding in their scripts.
+ */
+export function useColorPicker({ editorRef, monacoRef }: Params) {
+  watchEffect(onCleanup => {
+    const monaco = monacoRef.value;
+    const editor = editorRef.value;
+    if (!editor || !monaco) return;
+
+    const colorProvider: languages.DocumentColorProvider = {
+      provideColorPresentations(model, colorInfo) {
+        const color = colorInfo.color;
+        const red = Math.round(color.red * 255);
+        const green = Math.round(color.green * 255);
+        const blue = Math.round(color.blue * 255);
+        const alpha = Math.round(color.alpha * 255);
+        const c = (color: number) => color.toString(16).padStart(2, "0");
+        let label: string;
+        if (alpha === 255) {
+          label = `getColor("${c(red)}${c(green)}${c(blue)}")`;
+        } else {
+          label = `getColor("${c(red)}${c(green)}${c(blue)}${c(alpha)}")`;
+        }
+        return [{ label }];
+      },
+      provideDocumentColors(model) {
+        const text = model.getValue();
+
+        // allowing whitespace for more flexibility
+        const reg = /getColor\s*\(('|")([0-9a-fA-F]{0,8})('|")\s*\)/g;
+        let match;
+        const result: languages.IColorInformation[] = [];
+        while ((match = reg.exec(text))) {
+          const color = match[2];
+          const start = model.getPositionAt(match.index);
+          const end = model.getPositionAt(match.index + match[0].length);
+          result.push({
+            color: parseColor(color),
+            range: {
+              startLineNumber: start.lineNumber,
+              startColumn: start.column,
+              endLineNumber: end.lineNumber,
+              endColumn: end.column,
+            },
+          });
+        }
+        return result;
+      },
+    };
+
+    const tsDisposable = monaco.languages.registerColorProvider(
+      "typescript",
+      colorProvider,
+    );
+    const jsDisposable = monaco.languages.registerColorProvider(
+      "javascript",
+      colorProvider,
+    );
+
+    onCleanup(() => {
+      tsDisposable.dispose();
+      jsDisposable.dispose();
+    });
+  });
+}
+
+function parseColor(color: string) {
+  if (color.length !== 6 && color.length !== 8)
+    return { red: 0, green: 0, blue: 0, alpha: 1 };
+
+  const red = parseInt(color.slice(0, 2), 16) / 255;
+  const green = parseInt(color.slice(2, 4), 16) / 255;
+  const blue = parseInt(color.slice(4, 6), 16) / 255;
+  const alpha = color.length === 8 ? parseInt(color.slice(6, 8), 16) / 255 : 1;
+  return { red, green, blue, alpha };
+}

--- a/website/src/composables/useColorPicker.ts
+++ b/website/src/composables/useColorPicker.ts
@@ -20,17 +20,20 @@ export function useColorPicker({ editorRef, monacoRef }: Params) {
     const colorProvider: languages.DocumentColorProvider = {
       provideColorPresentations(model, colorInfo) {
         const color = colorInfo.color;
+        const originalText = model.getValueInRange(colorInfo.range);
+        // use the same quotes as the original text
+        const q = originalText.includes("'") ? "'" : '"';
+
         const red = Math.round(color.red * 255);
         const green = Math.round(color.green * 255);
         const blue = Math.round(color.blue * 255);
         const alpha = Math.round(color.alpha * 255);
         const c = (color: number) => color.toString(16).padStart(2, "0");
-        let label: string;
-        if (alpha === 255) {
-          label = `getColor("${c(red)}${c(green)}${c(blue)}")`;
-        } else {
-          label = `getColor("${c(red)}${c(green)}${c(blue)}${c(alpha)}")`;
-        }
+        const label =
+          alpha === 255
+            ? `getColor(${q}${c(red)}${c(green)}${c(blue)}${q})`
+            : `getColor(${q}${c(red)}${c(green)}${c(blue)}${c(alpha)}${q})`;
+
         return [{ label }];
       },
       provideDocumentColors(model) {


### PR DESCRIPTION
Closes #203.

This function allows users to access mlog color literals.

```js
const color = getColor("0e7eba");

draw.col(color);
draw.rect({ x: 0, y: 0, width: 500, height: 500 });

drawFlush();
```
output:
```
draw col %0e7eba
draw rect 0 0 500 500
drawflush display1
```